### PR TITLE
Improve script system

### DIFF
--- a/Code/CryCommon/CryScriptSystem/IScriptSystem.h
+++ b/Code/CryCommon/CryScriptSystem/IScriptSystem.h
@@ -586,7 +586,7 @@ struct IScriptTable
 
 	//! @param szPath e.g. "cnt.table1.table2", "", "mytable", max 255 characters
 	//! @return true=path was valid, false otherwise
-	//virtual bool GetValueRecursive( const char *szPath, IScriptTable *pObj ) = 0;
+	virtual bool GetValueRecursive( const char *szPath, IScriptTable *pObj ) = 0;
 };
 
 

--- a/Code/CryScriptSystem/ScriptBindings/ScriptBind_Movie.cpp
+++ b/Code/CryScriptSystem/ScriptBindings/ScriptBind_Movie.cpp
@@ -13,7 +13,6 @@ ScriptBind_Movie::ScriptBind_Movie(IScriptSystem* pSS)
 
 	SCRIPT_REG_TEMPLFUNC(PlaySequence, "sSequenceName");
 	SCRIPT_REG_TEMPLFUNC(StopSequence, "sSequenceName");
-	SCRIPT_REG_TEMPLFUNC(AbortSequence, "sSequenceName");
 	SCRIPT_REG_FUNC(StopAllSequences);
 	SCRIPT_REG_FUNC(StopAllCutScenes);
 	SCRIPT_REG_FUNC(PauseSequences);
@@ -40,24 +39,6 @@ int ScriptBind_Movie::StopSequence(IFunctionHandler *pH, const char *sSequenceNa
 
 	if (pMovieSystem)
 		pMovieSystem->StopSequence(sSequenceName);
-
-	return pH->EndFunction();
-}
-
-int ScriptBind_Movie::AbortSequence(IFunctionHandler *pH, const char *sSequenceName)
-{
-	bool leaveTime = false;
-	if (pH->GetParamCount() >= 2)
-		pH->GetParam(2, leaveTime);
-
-	IMovieSystem *pMovieSystem = gEnv->pMovieSystem;
-
-	if (pMovieSystem)
-	{
-		IAnimSequence *seq = pMovieSystem->FindSequence(sSequenceName);
-		if (seq)
-			pMovieSystem->AbortSequence(seq, leaveTime);
-	}
 
 	return pH->EndFunction();
 }

--- a/Code/CryScriptSystem/ScriptBindings/ScriptBind_Movie.h
+++ b/Code/CryScriptSystem/ScriptBindings/ScriptBind_Movie.h
@@ -7,34 +7,10 @@ class ScriptBind_Movie : public CScriptableBase
 public:
 	ScriptBind_Movie(IScriptSystem *pSS);
 
-	//! <code>Movie.PlaySequence(sSequenceName)</code>
-	//! <param name="sSequenceName">Sequence name.</param>
-	//! <description>Plays the specified sequence.</description>
 	int PlaySequence(IFunctionHandler *pH, const char *sSequenceName);
-
-	//! <code>Movie.StopSequence(sSequenceName)</code>
-	//! <param name="sSequenceName">Sequence name.</param>
-	//! <description>Stops the specified sequence.</description>
 	int StopSequence(IFunctionHandler *pH, const char *sSequenceName);
-
-	//! <code>Movie.AbortSequence(sSequenceName)</code>
-	//! <param name="sSequenceName">Sequence name.</param>
-	//! <description>Aborts the specified sequence.</description>
-	int AbortSequence(IFunctionHandler *pH, const char *sSequenceName);
-
-	//! <code>Movie.StopAllSequences()</code>
-	//! <description>Stops all the video sequences.</description>
 	int StopAllSequences(IFunctionHandler *pH);
-
-	//! <code>Movie.StopAllCutScenes()</code>
-	//! <description>Stops all the cut scenes.</description>
 	int StopAllCutScenes(IFunctionHandler *pH);
-
-	//! <code>Movie.PauseSequences()</code>
-	//! <description>Pauses all the sequences.</description>
 	int PauseSequences(IFunctionHandler *pH);
-
-	//! <code>Movie.ResumeSequences()</code>
-	//! <description>Resume all the sequences.</description>
 	int ResumeSequences(IFunctionHandler *pH);
 };

--- a/Code/CryScriptSystem/ScriptBindings/ScriptBind_Particle.cpp
+++ b/Code/CryScriptSystem/ScriptBindings/ScriptBind_Particle.cpp
@@ -1,5 +1,6 @@
 #include "CryCommon/CrySystem/ISystem.h"
 #include "CryCommon/Cry3DEngine/I3DEngine.h"
+#include "CryCommon/Cry3DEngine/CryParticleSpawnInfo.h"
 #include "CryCommon/CryEntitySystem/IEntitySystem.h"
 
 #include "ScriptBind_Particle.h"
@@ -9,11 +10,18 @@ ScriptBind_Particle::ScriptBind_Particle(IScriptSystem *pSS)
 	CScriptableBase::Init(pSS, gEnv->pSystem);
 	SetGlobalName("Particle");
 
+	pSS->SetGlobalValue("CRYPARTICLE_RAIN_MODE", CryParticleSpawnInfo::FLAGS_RAIN_MODE);
+	pSS->SetGlobalValue("CRYPARTICLE_ONE_TIME_SPAWN", CryParticleSpawnInfo::FLAGS_ONE_TIME_SPAWN);
+
+	pSS->SetGlobalValue("ParticleBlendType_AlphaBased", ParticleBlendType_AlphaBased);
+	pSS->SetGlobalValue("ParticleBlendType_ColorBased", ParticleBlendType_ColorBased);
+	pSS->SetGlobalValue("ParticleBlendType_Additive", ParticleBlendType_Additive);
+	pSS->SetGlobalValue("ParticleBlendType_None", ParticleBlendType_None);
+
 #undef SCRIPT_REG_CLASSNAME
 #define SCRIPT_REG_CLASSNAME &ScriptBind_Particle::
 
 	SCRIPT_REG_TEMPLFUNC(SpawnEffect, "effectName, pos, dir, [scale], [entityId], [partId]");
-	SCRIPT_REG_TEMPLFUNC(EmitParticle, "pos, dir, entityId, slotId");
 	SCRIPT_REG_TEMPLFUNC(CreateDecal, "pos, normal, size, lifeTime, textureName, [angle], [hitDirection], [entityId], [partid]");
 	SCRIPT_REG_TEMPLFUNC(CreateMatDecal, "pos, normal, size, lifeTime, materialName, [angle], [hitDirection], [entityId], [partid]");
 }
@@ -48,24 +56,6 @@ int ScriptBind_Particle::SpawnEffect(IFunctionHandler *pH, const char *effectNam
 	}
 
 	return pH->EndFunction(entitySlot);
-}
-
-int ScriptBind_Particle::EmitParticle(IFunctionHandler *pH, Vec3 pos, Vec3 dir, ScriptHandle entityId, int slotId)
-{
-	IEntity *pEntity = gEnv->pEntitySystem->GetEntity(static_cast<EntityId>(entityId.n));
-	if (!pEntity)
-		return pH->EndFunction();
-
-	IParticleEmitter *pEmitter = pEntity->GetParticleEmitter(slotId);
-	if (!pEmitter)
-		return pH->EndFunction();
-
-	QuatTS location(IDENTITY, pos, 1.0f);
-	location.q.SetRotationVDir(dir);
-
-	pEmitter->EmitParticle(nullptr, nullptr, &location, nullptr);
-
-	return pH->EndFunction();
 }
 
 static void SetAdditionalDecalInfo(CryEngineDecalInfo & decal, IFunctionHandler *pH)

--- a/Code/CryScriptSystem/ScriptBindings/ScriptBind_Particle.h
+++ b/Code/CryScriptSystem/ScriptBindings/ScriptBind_Particle.h
@@ -7,37 +7,7 @@ class ScriptBind_Particle : public CScriptableBase
 public:
 	ScriptBind_Particle(IScriptSystem *pSS);
 
-	//! <code>Particle.SpawnEffect( effectName, pos, dir )</code>
-	//! <param name="effectName">Effect name.</param>
-	//! <param name="pos">Position vector.</param>
-	//! <param name="dir">Direction vector.</param>
-	//! <return>SlotId where the emitter was bound to if a valid EntityId was given.</return>
-	//! <description>Spawns an effect.</description>
 	int SpawnEffect(IFunctionHandler *pH, const char *effectName, Vec3 pos, Vec3 dir);
-
-	//! <code>Particle.EmitParticle( pos, dir, entityId, slotId )</code>
-	//! <param name="pos">Particle position.</param>
-	//! <param name="dir">Particle direction.</param>
-	//! <param name="entityId">EntityId of the previously associated entity.</param>
-	//! <param name="slotId">SlotId where the emitter was bound to.</param>
-	//! <description>Emits an individual particle previously associanted with an entity.</description>
-	int EmitParticle(IFunctionHandler *pH, Vec3 pos, Vec3 dir, ScriptHandle entityId, int slotId);
-
-	//! <code>Particle.CreateDecal( pos, normal, size, lifeTime, textureName )</code>
-	//! <param name="pos">Decal position.</param>
-	//! <param name="normal">Decal normal vector.</param>
-	//! <param name="size">Decal size.</param>
-	//! <param name="lifeTime">Decal life time.</param>
-	//! <param name="textureName - Name of the texture.</param>
-	//! <description>Creates a decal with the specified parameters.</description>
 	int CreateDecal(IFunctionHandler *pH, Vec3 pos, Vec3 normal, float size, float lifeTime, const char *textureName);
-
-	//! <code>Particle.CreateMatDecal( pos, normal, size, lifeTime, materialName )</code>
-	//! <param name="pos">Decal position.</param>
-	//! <param name="normal">Decal normal vector.</param>
-	//! <param name="size">Decal size.</param>
-	//! <param name="lifeTime">Decal life time.</param>
-	//! <param name="materialName">Name of the Material.</param>
-	//! <description>Creates a material decal.</description>
 	int CreateMatDecal(IFunctionHandler *pH, Vec3 pos, Vec3 normal, float size, float lifeTime, const char *materialName);
 };

--- a/Code/CryScriptSystem/ScriptBindings/ScriptBind_Physics.h
+++ b/Code/CryScriptSystem/ScriptBindings/ScriptBind_Physics.h
@@ -7,66 +7,10 @@ class ScriptBind_Physics : public CScriptableBase
 public:
 	ScriptBind_Physics(IScriptSystem *pSS);
 
-	//! <code>Physics.SimulateExplosion( explosionParams )</code>
-	//! <description>
-	//! Simulate physical explosion.
-	//! Does not apply any game related explosion damages, this function only apply physical forces.
-	//! The parameters are passed as a table containing the elements described below.
-	//! </description>
-	//! <param name="pos">Explosion epicenter position.</param>
-	//! <param name="radius">Explosion radius.</param>
-	//! <param name="direction">Explosion impulse direction.</param>
-	//! <param name="impulse_pos">Explosion impulse position (Can be different from explosion epicenter).</param>
-	//! <param name="impulse_presure">Explosion impulse presur at radius distance from epicenter.</param>
-	//! <param name="rmin">Explosion minimal radius, at this radius full pressure is applied.</param>
-	//! <param name="rmax">Explosion maximal radius, at this radius impulse pressure will be reaching zero.</param>
-	//! <param name="hole_size">Size of the explosion hole to create in breakable objects.</param>
 	int SimulateExplosion(IFunctionHandler *pH, SmartScriptTable explosionParams);
-
-	//! <code>Physics.RegisterExplosionShape( sGeometryFile, fSize, nMaterialId, fProbability, sSplintersFile, fSplintersOffset, sSplintersCloudEffect )</code>
-	//! <description>
-	//! Register a new explosion shape from the static geometry.
-	//! Does not apply any game related explosion damages, this function only apply physical forces.
-	//! </description>
-	//! <param name="sGeometryFile">Static geometry file name (CGF).</param>
-	//! <param name="fSize">Scale for the static geometry.</param>
-	//! <param name="nMaterialId">ID of the breakable material to apply this shape on.</param>
-	//! <param name="fProbability">Preference ratio of using this shape then other registered shape.</param>
-	//! <param name="sSplintersFile">additional non-physicalized splinters cgf to place on cut surfaces.</param>
-	//! <param name="fSplintersOffset">the lower splinters piece wrt to the upper one.</param>
-	//! <param name="sSplintersCloudEffect">particle effect when the splinters constraint breaks.</param>
 	int RegisterExplosionShape(IFunctionHandler *pH, const char *sGeometryFile, float fSize, int nIdMaterial, float fProbability, const char *sSplintersFile, float fSplintersOffset, const char *sSplintersCloudEffect);
-
-	//! <code>Physics.RegisterExplosionCrack( sGeometryFile, int nMaterialId )</code>
-	//! <description>Register a new crack for breakable object.</description>
-	//! <param name="sGeometryFile">Static geometry file name fro the crack (CGF).</param>
-	//! <param name="nMaterialId">ID of the breakable material to apply this crack on.</param>
 	int RegisterExplosionCrack(IFunctionHandler *pH, const char *sGeometryFile, int nIdMaterial);
-
-	//bool ReadPhysicsTable(IScriptTable *pITable, PhysicsParams &sParamOut) {};
-
-	//! <code>Physics.RayWorldIntersection( vPos, vDir, nMaxHits, iEntTypes [, skipEntityId1 [, skipEntityId2]] )</code>
-	//! <description>Check if ray segment from src to dst intersect anything.</description>
-	//! <param name="vPos">Ray origin point.</param>
-	//! <param name="vDir">Ray direction.</param>
-	//! <param name="nMaxHits">Max number of hits to return, sorted in nearest to farest order.</param>
-	//! <param name="iEntTypes">Physical Entity types bitmask, ray will only intersect with entities specified by this mask (ent_all,...).</param>
-	//! <param name="skipEntityId1">(optional) Entity id to skip when checking for intersection.</param>
-	//! <param name="skipEntityId2">(optional) Entity id to skip when checking for intersection.</param>
 	int RayWorldIntersection(IFunctionHandler *pH);
-
-	//! <code>Physics.RayTraceCheck( src, dst, skipEntityId1, skipEntityId2 )</code>
-	//! <description>Check if ray segment from src to dst intersect anything.</description>
-	//! <param name="src">Ray segment origin point.</param>
-	//! <param name="dst">Ray segment end point.</param>
-	//! <param name="skipEntityId1">Entity id to skip when checking for intersection.</param>
-	//! <param name="skipEntityId2">Entity id to skip when checking for intersection.</param>
 	int RayTraceCheck(IFunctionHandler *pH, Vec3 src, Vec3 dst, ScriptHandle skipEntityId1, ScriptHandle skipEntityId2);
-
-	//! <code>Physics.SamplePhysEnvironment( pt, r [, objtypes] )</code>
-	//! <description>Find physical entities touched by a sphere.</description>
-	//! <param name="pt">center of sphere.</param>
-	//! <param name="r">radius of sphere.</param>
-	//! <param name="objtypes">(optional) physics entity types.</param>
 	int SamplePhysEnvironment(IFunctionHandler *pH);
 };

--- a/Code/CryScriptSystem/ScriptBindings/ScriptBind_Script.cpp
+++ b/Code/CryScriptSystem/ScriptBindings/ScriptBind_Script.cpp
@@ -35,9 +35,9 @@ int ScriptBind_Script::LoadScript(IFunctionHandler *pH)
 	if (pH->GetParamCount() >= 3)
 		pH->GetParam(3, raiseError);
 
-	bool reload = false;
+	bool forceReload = false;
 	if (pH->GetParamCount() >= 2)
-		pH->GetParam(2, reload);
+		pH->GetParam(2, forceReload);
 
 	const char *scriptFile = nullptr;
 	pH->GetParam(1, scriptFile);
@@ -46,7 +46,7 @@ int ScriptBind_Script::LoadScript(IFunctionHandler *pH)
 
 	if (scriptFile)
 	{
-		status = m_pSS->ExecuteFile(scriptFile, raiseError, reload);
+		status = m_pSS->ExecuteFile(scriptFile, raiseError, forceReload);
 	}
 
 	return pH->EndFunction(status);
@@ -59,7 +59,7 @@ int ScriptBind_Script::ReloadScript(IFunctionHandler *pH)
 		return pH->EndFunction();
 
 	const bool raiseError = true;
-	const bool forceReload = gEnv->bEditor;
+	const bool forceReload = false;
 
 	m_pSS->ExecuteFile(fileName, raiseError, forceReload);
 

--- a/Code/CryScriptSystem/ScriptBindings/ScriptBind_Script.h
+++ b/Code/CryScriptSystem/ScriptBindings/ScriptBind_Script.h
@@ -11,72 +11,13 @@ class ScriptBind_Script : public CScriptableBase
 public:
 	ScriptBind_Script(IScriptSystem *pSS);
 
-	//! <code>Script.LoadScript(scriptName)</code>
-	//! <description>Loads the script.</description>
-	//! <param name="scriptName">name of the script to load</param>
 	int LoadScript(IFunctionHandler *pH);
-
-	//! <code>Script.ReloadScript()</code>
-	//! <description>Reload the script.</description>
 	int ReloadScript(IFunctionHandler *pH);
-
-	//! <code>Script.ReloadScripts()</code>
-	//! <description>Reloads all the scripts.</description>
 	int ReloadScripts(IFunctionHandler *pH);
-
-	//! <code>Script.ReloadEntityScript( className )</code>
-	//! <param name="className">Name of the entity script.</param>
-	//! <description>Reloads the specified entity script.</description>
 	int ReloadEntityScript(IFunctionHandler *pH, const char *className);
-
-	//! <code>Script.UnloadScript()</code>
-	//! <description>Unloads the script.</description>
 	int UnloadScript(IFunctionHandler *pH);
-
-	//! <code>Script.DumpLoadedScripts()</code>
-	//! <description>Dumps all the loaded scripts.</description>
 	int DumpLoadedScripts(IFunctionHandler *pH);
-
-	//! <code>Script.SetTimer( nMilliseconds, luaFunction [, userData] )</code>
-	//! <description>
-	//!    Set a general script timer, when timer expires will call back a specified lua function.
-	//!    Lua function will accept 1 or 2 parameters,
-	//!    if userData is specified luaFunction must be:
-	//!      <pre>LuaCallback = function( userData,nTimerId )
-	//!        -- function body
-	//!      end;</pre>
-	//!    if userData is not specified luaFunction must be:
-	//!      <pre>LuaCallback = function( nTimerId )
-	//!        -- function body
-	//!      end;</pre>
-	//! </description>
-	//! <param name="nMilliseconds">Delay of trigger in milliseconds.</param>
-	//! <param name="luaFunction">.</param>
-	//! <param name="userData">(optional) Any user defined table passed to the callback function.</param>
-	//! <returns>ID assigned to this timer or nil if not specified.</returns>
 	int SetTimer(IFunctionHandler *pH, int nMilliseconds, HSCRIPTFUNCTION hFunc);
-
-	//! <code>Script.SetTimerForFunction( nMilliseconds, luaFunction [, userData] )</code>
-	//! <description>
-	//!    Set a general script timer, when timer expires will call back a specified lua function.
-	//!    Lua function will accept 1 or 2 parameters,
-	//!    if userData is specified luaFunction must be:
-	//!      <pre>LuaCallback = function( userData,nTimerId )
-	//!        -- function body
-	//!      end;</pre>
-	//!    if userData is not specified luaFunction must be:
-	//!      <pre>LuaCallback = function( nTimerId )
-	//!        -- function body
-	//!      end;</pre>
-	//!.</description>
-	//! <param name="nMilliseconds">Delay of trigger in milliseconds.</param>
-	//! <param name="luaFunction">.</param>
-	//! <param name="userData"> (optional) Any user defined table passed to the callback function.</param>
-	//! <returns>ID assigned to this timer or nil if not specified.</returns>
 	int SetTimerForFunction(IFunctionHandler *pH, int nMilliseconds, const char *sFunctionName);
-
-	//! <code>Script.KillTimer( nTimerId )</code>
-	//! <description>Stops a timer set by the Script.SetTimer function.</description>
-	//! <param name="nTimerId">ID of the timer returned by the Script.SetTimer function.</param>
 	int KillTimer(IFunctionHandler *pH, ScriptHandle nTimerId);
 };

--- a/Code/CryScriptSystem/ScriptBindings/ScriptBind_Sound.cpp
+++ b/Code/CryScriptSystem/ScriptBindings/ScriptBind_Sound.cpp
@@ -118,6 +118,8 @@ ScriptBind_Sound::ScriptBind_Sound(IScriptSystem *pSS)
 	pSS->SetGlobalValue("SOUNDSCALE_UNDERWATER", SOUNDSCALE_UNDERWATER);
 	pSS->SetGlobalValue("SOUNDSCALE_MISSIONHINT", SOUNDSCALE_MISSIONHINT);
 
+	pSS->SetGlobalValue("SOUND_VOLUMESCALEMISSIONHINT", 0.45f);
+
 	pSS->SetGlobalValue("SOUND_SEMANTIC_NONE", eSoundSemantic_None);
 	pSS->SetGlobalValue("SOUND_SEMANTIC_ONLYVOICE", eSoundSemantic_OnlyVoice);
 	pSS->SetGlobalValue("SOUND_SEMANTIC_NOVOICE", eSoundSemantic_NoVoice);

--- a/Code/CryScriptSystem/ScriptBindings/ScriptBind_System.cpp
+++ b/Code/CryScriptSystem/ScriptBindings/ScriptBind_System.cpp
@@ -16,7 +16,6 @@
 #include "CryCommon/CryMath/Cry_Camera.h"
 #include "CryCommon/CryMath/Cry_Geo.h"
 #include "CryCommon/CryRenderer/IRenderAuxGeom.h"
-#include "CryCommon/CrySystem/IBudgetingSystem.h"
 
 #include "ScriptBind_System.h"
 
@@ -67,10 +66,8 @@ ScriptBind_System::ScriptBind_System(IScriptSystem *pSS)
 	SCRIPT_REG_TEMPLFUNC(GetPhysicalEntitiesInBoxByClass, "center, radius, className");
 	SCRIPT_REG_TEMPLFUNC(GetEntitiesByClass, "EntityClass");
 	SCRIPT_REG_TEMPLFUNC(GetNearestEntityByClass, "center, radius, className");
-
 	SCRIPT_REG_TEMPLFUNC(GetEntityByName, "sEntityName");
 	SCRIPT_REG_TEMPLFUNC(GetEntityIdByName, "sEntityName");
-
 	SCRIPT_REG_FUNC(DeformTerrain);
 	SCRIPT_REG_FUNC(DeformTerrainUsingMat);
 	SCRIPT_REG_FUNC(ScreenToTexture);
@@ -81,54 +78,33 @@ ScriptBind_System::ScriptBind_System(IScriptSystem *pSS)
 	SCRIPT_REG_TEMPLFUNC(DrawAABB, "x, y, z, x2, y2, z2, r, g, b, a");
 	SCRIPT_REG_TEMPLFUNC(DrawOBB, "x, y, z, w, h, d, rx, ry, rz");
 	SCRIPT_REG_FUNC(SetGammaDelta);
-
 	SCRIPT_REG_FUNC(ShowConsole);
-
-	SCRIPT_REG_FUNC(GetConfigSpec);
 	SCRIPT_REG_FUNC(IsMultiplayer);
-
 	SCRIPT_REG_FUNC(SetPostProcessFxParam);
 	SCRIPT_REG_FUNC(GetPostProcessFxParam);
-
 	SCRIPT_REG_FUNC(SetScreenFx);
 	SCRIPT_REG_FUNC(GetScreenFx);
-
 	SCRIPT_REG_FUNC(SetCVar);
 	SCRIPT_REG_FUNC(GetCVar);
 	SCRIPT_REG_FUNC(AddCCommand);
-
 	SCRIPT_REG_FUNC(SetScissor);
-
-	SCRIPT_REG_FUNC(GetSystemMem);
 	SCRIPT_REG_FUNC(IsHDRSupported);
-
-	SCRIPT_REG_FUNC(SetBudget);
-	SCRIPT_REG_FUNC(SetVolumetricFogModifiers);
-
 	SCRIPT_REG_FUNC(SetWind);
 	SCRIPT_REG_FUNC(GetWind);
-
 	SCRIPT_REG_TEMPLFUNC(GetSurfaceTypeIdByName, "surfaceName");
 	SCRIPT_REG_TEMPLFUNC(GetSurfaceTypeNameById, "surfaceId");
-
 	SCRIPT_REG_TEMPLFUNC(RemoveEntity, "entityId");
 	SCRIPT_REG_TEMPLFUNC(SpawnEntity, "params");
-	SCRIPT_REG_FUNC(SetWaterVolumeOffset);
 	SCRIPT_REG_FUNC(IsValidMapPos);
 	SCRIPT_REG_FUNC(EnableOceanRendering);
 	SCRIPT_REG_FUNC(ScanDirectory);
-	SCRIPT_REG_FUNC(DebugStats);
-	SCRIPT_REG_FUNC(ViewDistanceSet);
 	SCRIPT_REG_FUNC(ViewDistanceGet);
 	SCRIPT_REG_FUNC(ApplyForceToEnvironment);
 	SCRIPT_REG_FUNC(GetOutdoorAmbientColor);
 	SCRIPT_REG_FUNC(GetTerrainElevation);
 	SCRIPT_REG_FUNC(ActivatePortal);
-	SCRIPT_REG_FUNC(DumpMMStats);
 	SCRIPT_REG_FUNC(IsPointIndoors);
 	SCRIPT_REG_TEMPLFUNC(ProjectToScreen, "point");
-	SCRIPT_REG_FUNC(DumpMemStats);
-	SCRIPT_REG_FUNC(DumpWinHeaps);
 	SCRIPT_REG_FUNC(Break);
 	SCRIPT_REG_TEMPLFUNC(SetViewCameraFov, "fov");
 	SCRIPT_REG_TEMPLFUNC(GetViewCameraFov, "");
@@ -141,36 +117,14 @@ ScriptBind_System::ScriptBind_System(IScriptSystem *pSS)
 	SCRIPT_REG_FUNC(SaveConfiguration);
 	SCRIPT_REG_FUNC(Quit);
 	SCRIPT_REG_FUNC(ClearKeyState);
-
 	SCRIPT_REG_TEMPLFUNC(SetSunColor, "vSunColor");
 	SCRIPT_REG_TEMPLFUNC(GetSunColor, "");
 	SCRIPT_REG_TEMPLFUNC(SetSkyColor, "vSkyColor");
 	SCRIPT_REG_TEMPLFUNC(GetSkyColor, "");
-
 	SCRIPT_REG_TEMPLFUNC(SetSkyHighlight, "tableSkyHighlightParams");
 	SCRIPT_REG_TEMPLFUNC(GetSkyHighlight, "");
-
 	SCRIPT_REG_TEMPLFUNC(LoadLocalizationXml, "filename");
-
 	SCRIPT_REG_FUNC(GetFrameID);
-}
-
-int ScriptBind_System::DumpMemStats(IFunctionHandler *pH)
-{
-	bool bUseKB = false;
-	if (pH->GetParamCount() > 0)
-		pH->GetParam(1, bUseKB);
-
-	gEnv->pSystem->DumpMemoryUsageStatistics(bUseKB);
-
-	return pH->EndFunction();
-}
-
-int ScriptBind_System::DumpWinHeaps(IFunctionHandler *pH)
-{
-	gEnv->pSystem->DumpWinHeaps();
-
-	return pH->EndFunction();
 }
 
 int ScriptBind_System::LoadFont(IFunctionHandler *pH)
@@ -359,17 +313,6 @@ int ScriptBind_System::ShowConsole(IFunctionHandler *pH)
 	gEnv->pConsole->ShowConsole(show != 0);
 
 	return pH->EndFunction();
-}
-
-int ScriptBind_System::GetConfigSpec(IFunctionHandler *pH)
-{
-	int obj_quality = CONFIG_VERYHIGH_SPEC;
-
-	ICVar *e_obj_quality = gEnv->pConsole->GetCVar("e_ObjQuality");
-	if (e_obj_quality)
-		obj_quality = e_obj_quality->GetIVal();
-
-	return pH->EndFunction(obj_quality);
 }
 
 int ScriptBind_System::IsMultiplayer(IFunctionHandler *pH)
@@ -689,7 +632,6 @@ int ScriptBind_System::GetPhysicalEntitiesInBox(IFunctionHandler *pH, Vec3 cente
 	return pH->EndFunction();
 }
 
-/////////////////////////////////////////////////////////////////////////////////
 int ScriptBind_System::GetPhysicalEntitiesInBoxByClass(IFunctionHandler *pH, Vec3 center, float radius, const char *className)
 {
 	IEntityClass *pClass = gEnv->pEntitySystem->GetClassRegistry()->FindClass(className);
@@ -734,7 +676,6 @@ int ScriptBind_System::GetPhysicalEntitiesInBoxByClass(IFunctionHandler *pH, Vec
 	return pH->EndFunction();
 }
 
-/////////////////////////////////////////////////////////////////////////////////
 int ScriptBind_System::GetNearestEntityByClass(IFunctionHandler *pH, Vec3 center, float radius, const char *className)
 {
 	IEntityClass *pClass = gEnv->pEntitySystem->GetClassRegistry()->FindClass(className);
@@ -1239,34 +1180,6 @@ int ScriptBind_System::IsValidMapPos(IFunctionHandler *pH)
 	return pH->EndFunction(isValid);
 }
 
-int ScriptBind_System::DebugStats(IFunctionHandler *pH)
-{
-	SCRIPT_CHECK_PARAMETERS(1);
-
-	bool cp;
-	pH->GetParam(1, cp);
-
-	gEnv->pSystem->DebugStats(cp, false);
-
-	return pH->EndFunction();
-}
-
-int ScriptBind_System::ViewDistanceSet(IFunctionHandler *pH)
-{
-	SCRIPT_CHECK_PARAMETERS(1);
-
-	float fViewDist;
-	pH->GetParam(1, fViewDist);
-
-	if (fViewDist < 20)
-		fViewDist = 20;
-
-	// TODO
-	//gEnv->p3DEngine->SetMaxViewDistance(fViewDist);
-
-	return pH->EndFunction();
-}
-
 int ScriptBind_System::ViewDistanceGet(IFunctionHandler *pH)
 {
 	SCRIPT_CHECK_PARAMETERS(0);
@@ -1399,17 +1312,6 @@ int ScriptBind_System::ActivatePortal(IFunctionHandler *pH)
 	return pH->EndFunction();
 }
 
-int ScriptBind_System::DumpMMStats(IFunctionHandler *pH)
-{
-	SCRIPT_CHECK_PARAMETERS(0);
-
-	gEnv->pSystem->DumpMMStats(true);
-	//m_pSS->GetMemoryStatistics(NULL);
-	gEnv->pLog->Log("***SCRIPT GC COUNT [%d kb]", m_pSS->GetCGCount());
-
-	return pH->EndFunction();
-}
-
 int ScriptBind_System::IsPointIndoors(IFunctionHandler *pH)
 {
 	SCRIPT_CHECK_PARAMETERS(1);
@@ -1461,15 +1363,6 @@ int ScriptBind_System::EnableOceanRendering(IFunctionHandler *pH)
 int ScriptBind_System::Break(IFunctionHandler *pH)
 {
 	gEnv->pSystem->Error("ScriptBind_System:Break");
-
-	return pH->EndFunction();
-}
-
-int ScriptBind_System::SetWaterVolumeOffset(IFunctionHandler *pH)
-{
-	SCRIPT_CHECK_PARAMETERS(4);
-
-	// TODO
 
 	return pH->EndFunction();
 }
@@ -1533,58 +1426,6 @@ int ScriptBind_System::IsHDRSupported(IFunctionHandler *pH)
 	SCRIPT_CHECK_PARAMETERS(0);
 
 	return pH->EndFunction(gEnv->pRenderer->GetFeatures() & RFT_HW_HDR);
-}
-
-int ScriptBind_System::SetBudget(IFunctionHandler *pH)
-{
-	SCRIPT_CHECK_PARAMETERS(7);
-
-	int sysMemLimitInMB = 512;
-	pH->GetParam(1, sysMemLimitInMB);
-
-	int videoMemLimitInMB = 256;
-	pH->GetParam(2, videoMemLimitInMB);
-
-	float frameTimeLimitInMS = 50.0f;
-	pH->GetParam(3, frameTimeLimitInMS);
-
-	int soundChannelsPlayingLimit = 64;
-	pH->GetParam(4, soundChannelsPlayingLimit);
-
-	int soundMemLimitInMB = 64;
-	pH->GetParam(5, soundMemLimitInMB);
-
-	int soundCPULimitInPercent = 5;
-	pH->GetParam(6, soundCPULimitInPercent);
-
-	int numDrawCallsLimit = 2000;
-	pH->GetParam(7, numDrawCallsLimit);
-
-	gEnv->pSystem->GetIBudgetingSystem()->SetBudget(
-		sysMemLimitInMB,
-		videoMemLimitInMB,
-		frameTimeLimitInMS,
-		soundChannelsPlayingLimit,
-		soundMemLimitInMB,
-		numDrawCallsLimit
-	);
-
-	return pH->EndFunction();
-}
-
-int ScriptBind_System::SetVolumetricFogModifiers(IFunctionHandler *pH)
-{
-	SCRIPT_CHECK_PARAMETERS(2);
-
-	float gobalDensityModifier(0);
-	pH->GetParam(1, gobalDensityModifier);
-
-	float atmosphereHeightModifier(0);
-	pH->GetParam(2, atmosphereHeightModifier);
-
-	CryLogWarning("System.SetVolumetricFogModifiers: Setting fog modifiers via fog entity not implemented!");
-
-	return pH->EndFunction();
 }
 
 int ScriptBind_System::SetWind(IFunctionHandler *pH)
@@ -1829,16 +1670,6 @@ int ScriptBind_System::SaveConfiguration(IFunctionHandler *pH)
 	gEnv->pSystem->SaveConfiguration();
 
 	return pH->EndFunction();
-}
-
-int ScriptBind_System::GetSystemMem(IFunctionHandler *pH)
-{
-	SCRIPT_CHECK_PARAMETERS(0);
-
-	// TODO
-	int iSysMemInMB = 0;
-
-	return pH->EndFunction(iSysMemInMB);
 }
 
 int ScriptBind_System::Quit(IFunctionHandler *pH)

--- a/Code/CryScriptSystem/ScriptBindings/ScriptBind_System.h
+++ b/Code/CryScriptSystem/ScriptBindings/ScriptBind_System.h
@@ -9,562 +9,88 @@ class ScriptBind_System : public CScriptableBase
 public:
 	ScriptBind_System(IScriptSystem *pSS);
 
-	//! <code>System.LoadFont(pszName)</code>
-	//! <param name="pszName">Font name.</param>
-	//! <description>Loads a font.</description>
 	int LoadFont(IFunctionHandler *pH);
-
-	//! <code>System.ExecuteCommand(szCmd)</code>
-	//! <param name="szCmd">Command string.</param>
-	//! <description>Executes a command.</description>
 	int ExecuteCommand(IFunctionHandler *pH);
-
-	//! <code>System.LogToConsole(sText)</code>
-	//! <param name="sText">Text to be logged.</param>
-	//! <description>Logs a message to the console.</description>
 	int LogToConsole(IFunctionHandler *pH);
-
-	//! <code>System.ClearConsole()</code>
-	//! <description>Clears the console.</description>
 	int ClearConsole(IFunctionHandler *pH);
-
-	//! <code>System.Log(sText)</code>
-	//! <param name="sText">Text to be logged.</param>
-	//! <description>Logs a message.</description>
 	int Log(IFunctionHandler *pH);
-
-	//! <code>System.LogAlways(sText)</code>
-	//! <param name="sText">Text to be logged.</param>
-	//! <description>Logs important data that must be printed regardless verbosity.</description>
 	int LogAlways(IFunctionHandler *pH);
-
-	//! <code>System.Warning(sText)</code>
-	//! <param name="sText">Text to be logged.</param>
-	//! <description>Shows a message text with the warning severity.</description>
 	int Warning(IFunctionHandler *pH);
-
-	//! <code>System.Error(sText)</code>
-	//! <param name="sText">Text to be logged.</param>
-	//! <description>Shows a message text with the error severity.</description>
 	int Error(IFunctionHandler *pH);
-
-	//! <code>System.IsEditor()</code>
-	//! <description>Checks if the system is the editor.</description>
 	int IsEditor(IFunctionHandler *pH);
-
-	//! <code>System.IsEditing()</code>
-	//! <description>Checks if the system is in pure editor mode, i.e. not editor game mode.</description>
 	int IsEditing(IFunctionHandler *pH);
-
-	//! <code>System.GetCurrTime()</code>
-	//! <description>Gets the current time.</description>
 	int GetCurrTime(IFunctionHandler *pH);
-
-	//! <code>System.GetCurrAsyncTime()</code>
-	//! <description>Gets the current asynchronous time.</description>
 	int GetCurrAsyncTime(IFunctionHandler *pH);
-
-	//! <code>System.GetFrameTime()</code>
-	//! <description>Gets the frame time.</description>
 	int GetFrameTime(IFunctionHandler *pH);
-
-	//! <code>System.GetLocalOSTime()</code>
-	//! <description>Gets the local operating system time.</description>
 	int GetLocalOSTime(IFunctionHandler *pH);
-
-	//! <code>System.GetUserName()</code>
-	//! <description>Gets the username on this machine.</description>
 	int GetUserName(IFunctionHandler *pH);
-
-	//! <code>System.ShowConsole(nParam)</code>
-	//! <param name="nParam">1 to show the console, 0 to hide.</param>
-	//! <description>Shows/hides the console.</description>
 	int ShowConsole(IFunctionHandler *pH);
-
-	//! <code>System.GetConfigSpec()</code>
-	//! <description>Gets the config specification.</description>
-	int GetConfigSpec(IFunctionHandler *pH);
-
-	//! <code>System.IsMultiplayer()</code>
-	//! <description>Checks if the game is multiplayer.</description>
 	int IsMultiplayer(IFunctionHandler *pH);
-
-	//! <code>System.GetEntity(entityId)</code>
-	//! <param name="entityId">Entity identifier.</param>
-	//! <description>Gets an entity from its ID.</description>
 	int GetEntity(IFunctionHandler *pH);
-
-	//! <code>System.GetEntityClass(entityId)</code>
-	//! <param name="entityId">Entity identifier.</param>
-	//! <description>Gets an entity class from its ID.</description>
 	int GetEntityClass(IFunctionHandler *pH);
-
-	//! <code>System.GetEntities(center, radius)</code>
-	//! <param name="center">Center position vector for the area where to get entities.</param>
-	//! <param name="radius">Radius of the area.</param>
-	//! <description>Gets all the entities contained in the specific area of the level.</description>
 	int GetEntities(IFunctionHandler *pH);
-
-	//! <code>System.GetEntitiesByClass(EntityClass)</code>
-	//! <param name="EntityClass">Entity class name.</param>
-	//! <description>Gets all the entities of the specified class.</description>
 	int GetEntitiesByClass(IFunctionHandler *pH, const char *EntityClass);
-
-	//! <code>System.GetEntitiesInSphere( centre, radius )</code>
-	//! <param name="centre">Centre position vector for the sphere where to look at entities.</param>
-	//! <param name="radius">Radius of the sphere.</param>
-	//! <description>Gets all the entities contained into the specified sphere.</description>
 	int GetEntitiesInSphere(IFunctionHandler *pH, Vec3 center, float radius);
-
-	//! <code>System.GetEntitiesInSphereByClass( centre, radius, EntityClass )</code>
-	//! <param name="centre">Centre position vector for the sphere where to look at entities.</param>
-	//! <param name="radius">Radius of the sphere.</param>
-	//! <param name="EntityClass">Entity class name.</param>
-	//! <description>Gets all the entities contained into the specified sphere for the specific class name.</description>
 	int GetEntitiesInSphereByClass(IFunctionHandler *pH, Vec3 center, float radius, const char *EntityClass);
-
-	//! <code>System.GetPhysicalEntitiesInBox( centre, radius )</code>
-	//! <param name="centre">Centre position vector for the area where to look at entities.</param>
-	//! <param name="radius">Radius of the sphere.</param>
-	//! <description>Gets all the entities contained into the specified area.</description>
 	int GetPhysicalEntitiesInBox(IFunctionHandler *pH, Vec3 center, float radius);
-
-	//! <code>System.GetPhysicalEntitiesInBoxByClass( centre, radius, className )</code>
-	//! <param name="centre">Centre position vector for the area where to look at entities.</param>
-	//! <param name="radius">Radius of the sphere.</param>
-	//! <param name="className">Entity class name.</param>
-	//! <description>Gets all the entities contained into the specified area for the specific class name.</description>
 	int GetPhysicalEntitiesInBoxByClass(IFunctionHandler *pH, Vec3 center, float radius, const char *className);
-
-	//! <code>System.GetNearestEntityByClass( centre, radius, className )</code>
-	//! <param name="centre">Centre position vector for the area where to look at entities.</param>
-	//! <param name="radius">Radius of the sphere.</param>
-	//! <param name="className">Entity class name.</param>
-	//! <description>Gets the nearest entity with the specified class.</description>
 	int GetNearestEntityByClass(IFunctionHandler *pH, Vec3 center, float radius, const char *className);
-
-	//! <code>System.GetEntityByName( sEntityName )</code>
-	//! <description>
-	//! Retrieve entity table for the first entity with specified name.
-	//! If multiple entities with same name exist, first one found is returned.
-	//! </description>
-	//! <param name="sEntityName">Name of the entity to search.</param>
 	int GetEntityByName(IFunctionHandler *pH, const char *sEntityName);
-
-	//! <code>System.GetEntityIdByName( sEntityName )</code>
-	//! <description>
-	//! Retrieve entity Id for the first entity with specified name.
-	//! If multiple entities with same name exist, first one found is returned.
-	//! </description>
-	//! <param name="sEntityName">Name of the entity to search.</param>
 	int GetEntityIdByName(IFunctionHandler *pH, const char *sEntityName);
-
-	//! <code>System.DrawLabel( vPos, fSize, text [, r [, g [, b [, alpha]]]] )</code>
-	//! <param name="vPos">Position vector.</param>
-	//! <param name="fSize">Size for the label.</param>
-	//! <param name="text">Text of the label.</param>
-	//! <param name="r">Red component for the label colour. Default is 1.</param>
-	//! <param name="g">Green component for the label colour. Default is 1.</param>
-	//! <param name="b">Blue component for the label colour. Default is 1.</param>
-	//! <param name="alpha">Alpha component for the label colour. Default is 1.</param>
-	//! <description>Draws a label with the specified parameter.</description>
 	int DrawLabel(IFunctionHandler *pH);
-
-	//! <code>System.DeformTerrain()</code>
-	//! <description>Deforms the terrain.</description>
 	int DeformTerrain(IFunctionHandler *pH);
-
-	//! <code>System.DeformTerrainUsingMat()</code>
-	//! <description>Deforms the terrain using material.</description>
 	int DeformTerrainUsingMat(IFunctionHandler *pH);
-
-	//! <code>System.ApplyForceToEnvironment( pos, force, radius)</code>
-	//! <param name="pos">Position of the force.</param>
-	//! <param name="force">Strength of the force.</param>
-	//! <param name="radius">Area where the force has effects.</param>
-	//! <description>Applies a force to the environment.</description>
 	int ApplyForceToEnvironment(IFunctionHandler *pH);
-
-	//! <code>System.ScreenToTexture()</code>
 	int ScreenToTexture(IFunctionHandler *pH);
-
-	//! <code>System.DrawTriStrip(handle, nMode, vtxs, r, g, b, alpha )</code>
-	//! <param name="handle">.</param>
-	//! <param name="nMode">.</param>
-	//! <param name="vtx">.</param>
-	//! <param name="r">Red component for the label color. Default is 1.</param>
-	//! <param name="g">Green component for the label color. Default is 1.</param>
-	//! <param name="b">Blue component for the label color. Default is 1.</param>
-	//! <param name="alpha">Alpha component for the label color. Default is 1.</param>
-	//! <description>Draws a triangle strip.</description>
-	int DrawTriStrip(IFunctionHandler *pH);
-
-	//! <code>System.DrawLine( p1, p2, r, g, b, alpha )</code>
-	//! <param name="p1">Start position of the line.</param>
-	//! <param name="p2">End position of the line.</param>
-	//! <param name="r">Red component for the label color. Default is 1.</param>
-	//! <param name="g">Green component for the label color. Default is 1.</param>
-	//! <param name="b">Blue component for the label color. Default is 1.</param>
-	//! <param name="alpha">Alpha component for the label color. Default is 1.</param>
-	//! <description>Draws a line.</description>
 	int DrawLine(IFunctionHandler *pH);
-
-	//! <code>System.Draw2DLine(p1x, p1y, p2x, p2y, r, g, b, alpha )</code>
-	//! <param name="p1x">X value of the start point of the line.</param>
-	//! <param name="p1y">Y value of the start point of the line.</param>
-	//! <param name="p2x">X value of the end point of the line.</param>
-	//! <param name="p2y">Y value of the end point of the line.</param>
-	//! <param name="r">Red component for the label color. Default is 1.</param>
-	//! <param name="g">Green component for the label color. Default is 1.</param>
-	//! <param name="b">Blue component for the label color. Default is 1.</param>
-	//! <param name="alpha">Alpha component for the label color. Default is 1.</param>
-	//! <description>Draws a 2D line.</description>
 	int Draw2DLine(IFunctionHandler *pH);
-
-	//! <code>System.DrawText( x, y, text, font, size, p2y, r, g, b, alpha )</code>
-	//! <param name="x">X position for the text.</param>
-	//! <param name="y">Y position for the text.</param>
-	//! <param name="text">Text to be displayed.</param>
-	//! <param name="font">Font name.</param>
-	//! <param name="size">Text size.</param>
-	//! <param name="r">Red component for the label color. Default is 1.</param>
-	//! <param name="g">Green component for the label color. Default is 1.</param>
-	//! <param name="b">Blue component for the label color. Default is 1.</param>
-	//! <param name="alpha">Alpha component for the label color. Default is 1.</param>
-	//! <description>Draws text.</description>
 	int DrawText(IFunctionHandler *pH);
-
-	//! <code>System.DrawSphere( x, y, z, radius, r, g, b, a )</code>
-	//! <param name="x">X position for the centre of the sphere.</param>
-	//! <param name="y">Y position for the centre of the sphere.</param>
-	//! <param name="z">Z position for the centre of the sphere.</param>
-	//! <param name="radius">Radius of the sphere.</param>
-	//! <param name="r">Red component for the sphere color. Default is 1.</param>
-	//! <param name="g">Green component for the sphere color. Default is 1.</param>
-	//! <param name="b">Blue component for the sphere color. Default is 1.</param>
-	//! <param name="a">Alpha component for the sphere color. Default is 1.</param>
-	//! <description>Draws a wireframe sphere.</description>
 	int DrawSphere(IFunctionHandler *pH, float x, float y, float z, float radius, int r, int g, int b, int a);
-
-	//! <code>System.DrawAABB( x, y, z, x2, y2, z2, r, g, b, a )</code>
-	//! <param name="x">X position of first corner.</param>
-	//! <param name="y">Y position of first corner.</param>
-	//! <param name="z">Z position of first corner.</param>
-	//! <param name="x2">X position of second corner.</param>
-	//! <param name="y2">Y position of second corner.</param>
-	//! <param name="z2">Z position of second corner.</param>
-	//! <param name="r">Red component for the sphere color. Default is 1.</param>
-	//! <param name="g">Green component for the sphere color. Default is 1.</param>
-	//! <param name="b">Blue component for the sphere color. Default is 1.</param>
-	//! <param name="a">Alpha component for the sphere color. Default is 1.</param>
-	//! <description>Draws a axis aligned box.</description>
 	int DrawAABB(IFunctionHandler *pH, float x, float y, float z, float x2, float y2, float z2, int r, int g, int b, int a);
-
-	//! <code>System.DrawAABB( x, y, z, x2, y2, z2, r, g, b, a )</code>
-	//! <param name="x">X component of the centre point of the box.</param>
-	//! <param name="y">Y component of the centre point of the box.</param>
-	//! <param name="z">Z component of the centre point of the box.</param>
-	//! <param name="w">Width of the box.</param>
-	//! <param name="h">Height of the box.</param>
-	//! <param name="d">Depth of the box.</param>
-	//! <param name="rx">Rotation in X of the box.</param>
-	//! <param name="ry">Rotation in X of the box.</param>
-	//! <param name="rz">Rotation in X of the box.</param>
-	//! <description>Draws an object bounding box.</description>
 	int DrawOBB(IFunctionHandler *pH, float x, float y, float z, float w, float h, float d, float rx, float ry, float rz);
-
-	//! <code>System.SetGammaDelta( fDelta )</code>
-	//! <param name="fDelta">Delta value.</param>
-	//! <description>Sets the gamma/delta value.</description>
 	int SetGammaDelta(IFunctionHandler *pH);
-
-	//! <code>System.SetPostProcessFxParam( pszEffectParam, value )</code>
-	//! <param name="pszEffectParam">Parameter for the post processing effect.</param>
-	//! <param name="value">Value for the parameter.</param>
-	//! <description>Sets a post processing effect parameter value.</description>
 	int SetPostProcessFxParam(IFunctionHandler *pH);
-
-	//! <code>System.GetPostProcessFxParam( pszEffectParam, value )</code>
-	//! <param name="pszEffectParam">Parameter for the post processing effect.</param>
-	//! <param name="value">Value for the parameter.</param>
-	//! <description>Gets a post processing effect parameter value.</description>
 	int GetPostProcessFxParam(IFunctionHandler *pH);
-
-	//! <code>System.SetScreenFx( pszEffectParam, value )</code>
-	//! <param name="pszEffectParam">Parameter for the post processing effect.</param>
-	//! <param name="value">Value for the parameter.</param>
-	//! <description>Sets a post processing effect parameter value.</description>
 	int SetScreenFx(IFunctionHandler *pH);
-
-	//! <code>System.GetScreenFx( pszEffectParam, value )</code>
-	//! <param name="pszEffectParam">Parameter for the post processing effect.</param>
-	//! <param name="value">Value for the parameter.</param>
-	//! <description>Gets a post processing effect parameter value.</description>
 	int GetScreenFx(IFunctionHandler *pH);
-
-	//! <code>System.SetCVar( sCVarName, value )</code>
-	//! <param name="sCVarName">Name of the variable.</param>
-	//! <param name="value">Value of the variable.</param>
-	//! <description>Sets the value of a CVariable.</description>
 	int SetCVar(IFunctionHandler *pH);
-
-	//! <code>System.GetCVar( sCVarName)</code>
-	//! <param name="sCVarName">Name of the variable.</param>
-	//! <description>Gets the value of a CVariable.</description>
 	int GetCVar(IFunctionHandler *pH);
-
-	//! <code>System.AddCCommand( sCCommandName, sCommand, sHelp)</code>
-	//! <param name="sCCommandName">C command name.</param>
-	//! <param name="sCommand">Command string.</param>
-	//! <param name="sHelp">Help for the command usage.</param>
-	//! <description>Adds a C command to the system.</description>
 	int AddCCommand(IFunctionHandler *pH);
-
-	//! <code>System.SetScissor( x, y, w, h )</code>
-	//! <param name="x">X position.</param>
-	//! <param name="y -	Y position.</param>
-	//! <param name="w">Width size.</param>
-	//! <param name="h">Height size.</param>
-	//! <description>Sets scissor info.</description>
 	int SetScissor(IFunctionHandler *pH);
-
-	//! <code>System.GetSystemMem()</code>
-	//! <description>Gets the amount of the memory for the system.</description>
-	int GetSystemMem(IFunctionHandler *pH);
-
-	//! <code>System.IsHDRSupported()</code>
-	//! <description>Checks if the HDR is supported.</description>
 	int IsHDRSupported(IFunctionHandler *pH);
-
-	//! <code>System.SetBudget(sysMemLimitInMB, videoMemLimitInMB, frameTimeLimitInMS, soundChannelsPlayingLimit, soundMemLimitInMB, numDrawCallsLimit )</code>
-	//! <param name="sysMemLimitInMB">Limit of the system memory in MB.</param>
-	//! <param name="videoMemLimitInMB">Limit of the video memory in MB.</param>
-	//! <param name="frameTimeLimitInMS">Limit in the frame time in MS.</param>
-	//! <param name="soundChannelsPlayingLimit">Limit of the sound channels playing.</param>
-	//! <param name="soundMemLimitInMB">Limit of the sound memory in MB.</param>
-	//! <param name="numDrawCallsLimit">Limit of the draw calls.</param>
-	//! <description>Sets system budget.</description>
-	int SetBudget(IFunctionHandler *pH);
-
-	//! <code>System.SetVolumetricFogModifiers( gobalDensityModifier, atmosphereHeightModifier )</code>
-	//! <param name="gobalDensityModifier">Modifier for the global density.</param>
-	//! <param name="atmosphereHeightModifier">Modifier for the atmosphere height.</param>
-	//! <description>Sets the volumetric fog modifiers.</description>
-	int SetVolumetricFogModifiers(IFunctionHandler *pH);
-
-	//! <code>System.SetWind( vWind )</code>
-	//! <param name="vWind">Wind direction.</param>
-	//! <description>Sets the wind direction.</description>
 	int SetWind(IFunctionHandler *pH);
-
-	//! <code>System.SetWind()</code>
-	//! <description>Gets the wind direction.</description>
 	int GetWind(IFunctionHandler *pH);
-
-	//! <code>System.GetSurfaceTypeIdByName( surfaceName )</code>
-	//! <param name="surfaceName">Surface name.</param>
-	//! <description>Gets the surface type identifier by its name.</description>
 	int GetSurfaceTypeIdByName(IFunctionHandler *pH, const char *surfaceName);
-
-	//! <code>System.GetSurfaceTypeNameById( surfaceId )</code>
-	//! <param name="surfaceId">Surface identifier.</param>
-	//! <description>Gets the surface type name by its identifier.</description>
 	int GetSurfaceTypeNameById(IFunctionHandler *pH, int surfaceId);
-
-	//! <code>System.RemoveEntity( entityId )</code>
-	//! <param name="entityId">Entity identifier.</param>
-	//! <description>Removes the specified entity.</description>
 	int RemoveEntity(IFunctionHandler *pH, ScriptHandle entityId);
-
-	//! <code>System.SpawnEntity( params )</code>
-	//! <param name="params">Entity parameters.</param>
-	//! <description>Spawns an entity.</description>
 	int SpawnEntity(IFunctionHandler *pH, SmartScriptTable params);
-
-	//! <code>System.SetWaterVolumeOffset()</code>
-	//! <description>SetWaterLevel is not supported by 3dengine for now.</description>
-	int SetWaterVolumeOffset(IFunctionHandler *pH);
-
-	//! <code>System.IsValidMapPos( v )</code>
-	//! <param name="v">Position vector.</param>
-	//! <description>Checks if the position is a valid map position.</description>
 	int IsValidMapPos(IFunctionHandler *pH);
-
-	//! <code>System.EnableOceanRendering()</code>
-	//! <param name="bOcean">True to activate the ocean rendering, false to deactivate it.</param>
-	//! <description>Enables/disables ocean rendering.</description>
 	int EnableOceanRendering(IFunctionHandler *pH);
-
-	//! <code>System.ScanDirectory( pszFolderName, nScanMode )</code>
-	//! <param name="pszFolderName">Folder name.</param>
-	//! <param name="nScanMode">Scan mode for the folder. Can be:
-	//! 		SCANDIR_ALL
-	//! 		SCANDIR_FILES
-	//! 		SCANDIR_SUBDIRS</param>
-	//! <description>Scans a directory.</description>
 	int ScanDirectory(IFunctionHandler *pH);
-
-	//! <code>System.DebugStats( cp )</code>
-	int DebugStats(IFunctionHandler *pH);
-
-	//! <code>System.ViewDistanceSet( fViewDist )</code>
-	//! <param name="fViewDist">View distance.</param>
-	//! <description>Sets the view distance.</description>
-	int ViewDistanceSet(IFunctionHandler *pH);
-
-	//! <code>System.ViewDistanceSet()</code>
-	//! <description>Gets the view distance.</description>
 	int ViewDistanceGet(IFunctionHandler *pH);
-
-	//! <code>System.GetOutdoorAmbientColor()</code>
-	//! <description>Gets the outdoor ambient color.</description>
 	int GetOutdoorAmbientColor(IFunctionHandler *pH);
-
-	//! <code>System.GetTerrainElevation( v3Pos )</code>
-	//! <param name="v3Pos">Position of the terraint to be checked.</param>
-	//! <description>Gets the terrain elevation of the specified position.</description>
 	int GetTerrainElevation(IFunctionHandler *pH);
-
-	//! <code>System.ActivatePortal( vPos, bActivate, nID )</code>
-	//! <param name="vPos">Position vector.</param>
-	//! <param name="bActivate">True to activate the portal, false to deactivate.</param>
-	//! <param name="nID">Entity identifier.</param>
-	//! <description>Activates/deactivates a portal.</description>
 	int ActivatePortal(IFunctionHandler *pH);
-
-	//! <code>System.DumpMMStats()</code>
-	//! <description>Dumps the MM statistics.</description>
-	int DumpMMStats(IFunctionHandler *pH);
-
-	//! <code>System.IsPointIndoors( vPos )</code>
-	//! <param name="vPos">Position vector.</param>
-	//! <description>Checks if a point is indoors.</description>
 	int IsPointIndoors(IFunctionHandler *pH);
-
-	//! <code>System.ProjectToScreen( vec )</code>
-	//! <param name="vec">Position vector.</param>
-	//! <description>Projects to the screen (not guaranteed to work if used outside Renderer).</description>
 	int ProjectToScreen(IFunctionHandler *pH, Vec3 vec);
-
-	//! <code>System.DumpMemStats( bUseKB )</code>
-	//! <param name="bUseKB">True to use KB, false otherwise.</param>
-	//! <description>Dumps memory statistics.</description>
-	int DumpMemStats(IFunctionHandler *pH);
-
-	//! <code>System.DumpWinHeaps()</code>
-	//! <description>Dumps windows heaps.</description>
-	int DumpWinHeaps(IFunctionHandler *pH);
-
-	//! <code>System.Break()</code>
-	//! <description>Breaks the application with a fatal error message.</description>
 	int Break(IFunctionHandler *pH);
-
-	//! <code>System.SetViewCameraFov( fov )</code>
-	//! <description>Sets the view camera fov.</description>
 	int SetViewCameraFov(IFunctionHandler *pH, float fov);
-
-	//! <code>System.GetViewCameraFov()</code>
-	//! <description>Gets the view camera fov.</description>
 	int GetViewCameraFov(IFunctionHandler *pH);
-
-	//! <code>System.IsPointVisible( point )</code>
-	//! <param name="point">Point vector.</param>
-	//! <description>Checks if the specified point is visible.</description>
 	int IsPointVisible(IFunctionHandler *pH, Vec3 point);
-
-	//! <code>System.GetViewCameraPos()</code>
-	//! <description>Gets the view camera position.</description>
 	int GetViewCameraPos(IFunctionHandler *pH);
-
-	//! <code>System.GetViewCameraDir()</code>
-	//! <description>Gets the view camera direction.</description>
 	int GetViewCameraDir(IFunctionHandler *pH);
-
-	//! <code>System.GetViewCameraUpDir()</code>
-	//! <description>Gets the view camera up-direction.</description>
 	int GetViewCameraUpDir(IFunctionHandler *pH);
-
-	//! <code>System.GetViewCameraAngles()</code>
-	//! <description>Gets the view camera angles.</description>
 	int GetViewCameraAngles(IFunctionHandler *pH);
-
-	//! <code>System.IsDevModeEnable()</code>
-	//! <description>
-	//! Checks if game is running in dev mode (cheat mode)
-	//! to check if we are allowed to enable certain scripts
-	//! function facilities (god mode, fly mode etc.).
-	//! </description>
 	int IsDevModeEnable(IFunctionHandler *pH);
-
-	//! <code>System.SaveConfiguration()</code>
-	//! <description>Saves the configuration.</description>
 	int SaveConfiguration(IFunctionHandler *pH);
-
-	//! <code>System.Quit()</code>
-	//! <description>Quits the program.</description>
 	int Quit(IFunctionHandler *pH);
-
-	//! <code>System.GetHDRDynamicMultiplier()</code>
-	//! <description>Gets the HDR dynamic multiplier.</description>
-	int GetHDRDynamicMultiplier(IFunctionHandler *pH);
-
-	//! <code>System.SetHDRDynamicMultiplier( fMul )</code>
-	//! <param name="fMul">Dynamic multiplier value.</param>
-	//! <description>Sets the HDR dynamic multiplier.</description>
-	int SetHDRDynamicMultiplier(IFunctionHandler *pH);
-
-	//! <code>System.GetFrameID()</code>
-	//! <description>Gets the frame identifier.</description>
 	int GetFrameID(IFunctionHandler *pH);
-
-	//! <code>System.ClearKeyState()</code>
-	//! <description>Clear the key state.</description>
 	int ClearKeyState(IFunctionHandler *pH);
-
-	//! <code>System.SetSunColor( vColor )</code>
-	//! <description>Set color of the sun, only relevant outdoors.</description>
-	//! <param name="vColor">Sun Color as an {x,y,z} vector (x=r,y=g,z=b).</param>
 	int SetSunColor(IFunctionHandler *pH, Vec3 vColor);
-
-	//! <code>Vec3 System.GetSunColor()</code>
-	//! <description>Retrieve color of the sun outdoors.</description>
-	//! <returns>Sun Color as an {x,y,z} vector (x=r,y=g,z=b).</returns>
 	int GetSunColor(IFunctionHandler *pH);
-
-	//! <code>System.SetSkyColor( vColor )</code>
-	//! <description>Set color of the sky (outdoors ambient color).</description>
-	//! <param name="vColor">Sky Color as an {x,y,z} vector (x=r,y=g,z=b).</param>
 	int SetSkyColor(IFunctionHandler *pH, Vec3 vColor);
-
-	//! <code>Vec3 System.GetSkyColor()</code>
-	//! <description>Retrieve color of the sky (outdoor ambient color).</description>
-	//! <returns>Sky Color as an {x,y,z} vector (x=r,y=g,z=b).</returns>
 	int GetSkyColor(IFunctionHandler *pH);
-
-	//! <code>System.SetSkyHighlight( params )</code>
-	//! <description>Set Sky highlighing parameters.</description>
-	//! <seealso cref="GetSkyHighlight">
-	//! <param name="params">Table with Sky highlighing parameters.
-	//!   <para>
-	//!     Highligh Params     Meaning
-	//!     -------------       -----------
-	//!     size                Sky highlight scale.
-	//!     color               Sky highlight color.
-	//!     direction           Direction of the sky highlight in world space.
-	//!     pod                 Position of the sky highlight in world space.
-	//!   </para>
-	//! </param>
 	int SetSkyHighlight(IFunctionHandler *pH, SmartScriptTable params);
-
-	//! <code>System.SetSkyHighlight( params )</code>
-	//! <description>
-	//! Retrieves Sky highlighing parameters.
-	//! see SetSkyHighlight for parameters description.
-	//! </description>
-	//! <seealso cref="SetSkyHighlight">
 	int GetSkyHighlight(IFunctionHandler *pH, SmartScriptTable params);
-
-	//! <code>System.LoadLocalizationXml( filename )</code>
-	//! <description>Loads Excel exported xml file with text and dialog localization data.</description>
 	int LoadLocalizationXml(IFunctionHandler *pH, const char *filename);
 };

--- a/Code/CryScriptSystem/ScriptSystem.h
+++ b/Code/CryScriptSystem/ScriptSystem.h
@@ -14,7 +14,7 @@ struct IConsoleCmdArgs;
 class ScriptSystem : public IScriptSystem
 {
 	lua_State *m_L = nullptr;
-	int m_funcParamCount = 0;
+	int m_funcParamCount = -1;
 	int m_errorHandlerRef = 0;
 
 	ScriptTimerManager m_timers;

--- a/Code/CryScriptSystem/ScriptSystem.h
+++ b/Code/CryScriptSystem/ScriptSystem.h
@@ -16,22 +16,20 @@ class ScriptSystem : public IScriptSystem
 	lua_State *m_L = nullptr;
 	int m_funcParamCount = -1;
 	int m_errorHandlerRef = 0;
+	int m_nestedForceReload = 0;
 
 	ScriptTimerManager m_timers;
 	ScriptBindings m_bindings;
 
 	struct Script
 	{
-		std::string name;
+		std::string sanitizedName;
 		std::string prettyName;
+
+		bool operator<(const std::string& name) const { return this->sanitizedName < name; }
 	};
 
 	std::vector<Script> m_scripts;
-
-	constexpr auto GetScriptNameCompare() const
-	{
-		return [](const Script& script, const std::string& name) { return script.name < name; };
-	}
 
 public:
 	ScriptSystem();
@@ -123,7 +121,8 @@ private:
 	void LuaGarbageCollectFull();
 	bool LuaCall(int paramCount, int resultCount);
 
-	std::string SanitizeScriptFileName(const char *fileName);
+	bool AddToScripts(const char *fileName);
+	bool RemoveFromScripts(const char *fileName);
 
 	static int ErrorHandler(lua_State *L);
 	static int PanicHandler(lua_State *L);

--- a/Code/CryScriptSystem/ScriptTable.cpp
+++ b/Code/CryScriptSystem/ScriptTable.cpp
@@ -73,7 +73,7 @@ void ScriptTable::PushRef()
 	}
 	else
 	{
-		CryLogWarning("[Script] Pushing Nil table reference");
+		CryLogWarningAlways("[Script] Pushing nil table");
 
 		lua_pushnil(m_L);
 	}

--- a/Code/CryScriptSystem/ScriptTable.cpp
+++ b/Code/CryScriptSystem/ScriptTable.cpp
@@ -485,6 +485,12 @@ bool ScriptTable::AddFunction(const SUserFunctionDesc & fd)
 	return true;
 }
 
+bool ScriptTable::GetValueRecursive(const char *path, IScriptTable *pTable)
+{
+	CryLogErrorAlways("[ScriptTable::GetValueRecursive] Should not be used");
+	return false;
+}
+
 ///////////////////////
 // Private functions //
 ///////////////////////

--- a/Code/CryScriptSystem/ScriptTable.h
+++ b/Code/CryScriptSystem/ScriptTable.h
@@ -64,6 +64,8 @@ public:
 
 	bool AddFunction(const SUserFunctionDesc & fd) override;
 
+	bool GetValueRecursive(const char *path, IScriptTable *pTable) override;
+
 private:
 	void CloneTable(int srcTableIndex, int dstTableIndex);
 	void CloneTableRecursive(int srcTableIndex, int dstTableIndex);


### PR DESCRIPTION
- Implement nested `GetGlobalAny` (close #105).
- Implement nested `SetGlobalAny` (new feature).
- Add more log messages when something fails and improve existing ones.
- Always log failed script execution.
- Fix nested forced script reloading.
- Fix default value of `m_funcParamCount`.
- Remove useless comments from script bindings.
- Remove the following unimplemented script bindings:
    - `System.ViewDistanceSet`
    - `System.SetWaterVolumeOffset`
    - `System.SetVolumetricFogModifiers`
    - `System.GetSystemMem`
- Remove the following unused script bindings:
    - `Movie.AbortSequence`
    - `Particle.EmitParticle`
    - `System.DumpMemStats`
    - `System.DumpWinHeaps`
    - `System.GetConfigSpec`
    - `System.DebugStats`
    - `System.DumpMMStats`
    - `System.SetBudget`
- Add the following missing script globals:
    - `CRYPARTICLE_RAIN_MODE`
    - `CRYPARTICLE_ONE_TIME_SPAWN`
    - `ParticleBlendType_AlphaBased`
    - `ParticleBlendType_ColorBased`
    - `ParticleBlendType_Additive`
    - `ParticleBlendType_None`
    - `SOUND_VOLUMESCALEMISSIONHINT`
- Add hidden and unused (?) `IScriptTable::GetValueRecursive` function to avoid potential crashes.