### PR TITLE
Improve CFlashMenuObject::UpdateNetwork

### DIFF
--- a/Code/CryGame/Menus/FlashMenuObject.cpp
+++ b/Code/CryGame/Menus/FlashMenuObject.cpp
@@ -4016,7 +4016,7 @@ void CFlashMenuObject::UpdateNetwork(float fDeltaTime)
 		return;
 	}
 
-	if (!m_multiplayerMenu->IsInLobby() && !m_multiplayerMenu->IsInLogin())
+	if (!m_multiplayerMenu->IsInLobby() && !m_multiplayerMenu->IsInLogin() && !gEnv->bMultiplayer)
 	{
 		m_pCurrentFlashMenuScreen->CheckedInvoke("setNetwork", true);
 	}

--- a/Code/CryGame/Menus/FlashMenuObject.cpp
+++ b/Code/CryGame/Menus/FlashMenuObject.cpp
@@ -45,6 +45,7 @@ History:
 
 #include "config.h"
 #include "CryMP/Client/Client.h"
+#include "CryMP/Client/ServerBrowser.h"
 #include "CryMP/Client/ServerConnector.h"
 #include "Library/StringTools.h"
 #include "CrySystem/LocalizationManager.h"
@@ -3282,6 +3283,8 @@ void CFlashMenuObject::OnPostUpdate(float fDeltaTime)
 		m_pFlashPlayer->Render();
 	}
 
+	UpdateNetwork(fDeltaTime);
+
 	// When we quit the game for the main menu or we load a game while we are already playing, there is a
 	// few frames where there is no more ingame menu and the main menu is not yet initialized/rendered.
 	// We fix the problem by displaying a black screen during this time.
@@ -4002,6 +4005,26 @@ void CFlashMenuObject::CloseWaitingScreen()
 	m_bLoadingDone = false;
 	m_bUpdate = false;
 	m_nBlackGraceFrames = gEnv->pRenderer->GetFrameID(false) + BLACK_FRAMES;
+}
+
+//-----------------------------------------------------------------------------------------------------
+
+void CFlashMenuObject::UpdateNetwork(float fDeltaTime)
+{
+	if (!gEnv || !gEnv->pNetwork || !m_pCurrentFlashMenuScreen || !m_multiplayerMenu)
+	{
+		return;
+	}
+
+	if (!m_multiplayerMenu->IsInLobby() && !m_multiplayerMenu->IsInLogin())
+	{
+		m_pCurrentFlashMenuScreen->CheckedInvoke("setNetwork", true);
+	}
+	else if (IsOnScreen(MENUSCREEN_FRONTENDSTART) || IsOnScreen(MENUSCREEN_FRONTENDINGAME))
+	{
+		bool bNetwork = gClient->GetServerBrowser()->LastRequestSucceeded();
+		m_pCurrentFlashMenuScreen->CheckedInvoke("setNetwork", bNetwork);
+	}
 }
 
 //-----------------------------------------------------------------------------------------------------

--- a/Code/CryGame/Menus/FlashMenuObject.cpp
+++ b/Code/CryGame/Menus/FlashMenuObject.cpp
@@ -3282,8 +3282,6 @@ void CFlashMenuObject::OnPostUpdate(float fDeltaTime)
 		m_pFlashPlayer->Render();
 	}
 
-	UpdateNetwork(fDeltaTime);
-
 	// When we quit the game for the main menu or we load a game while we are already playing, there is a
 	// few frames where there is no more ingame menu and the main menu is not yet initialized/rendered.
 	// We fix the problem by displaying a black screen during this time.
@@ -4004,22 +4002,6 @@ void CFlashMenuObject::CloseWaitingScreen()
 	m_bLoadingDone = false;
 	m_bUpdate = false;
 	m_nBlackGraceFrames = gEnv->pRenderer->GetFrameID(false) + BLACK_FRAMES;
-}
-
-//-----------------------------------------------------------------------------------------------------
-
-void CFlashMenuObject::UpdateNetwork(float fDeltaTime)
-{
-	if (!gEnv || !gEnv->pNetwork || !m_pCurrentFlashMenuScreen || !m_multiplayerMenu)
-		return;
-
-	if (!m_multiplayerMenu->IsInLobby() && !m_multiplayerMenu->IsInLogin() && !gEnv->bMultiplayer)
-		m_pCurrentFlashMenuScreen->CheckedInvoke("setNetwork", true);
-	else if (IsOnScreen(MENUSCREEN_FRONTENDSTART) || IsOnScreen(MENUSCREEN_FRONTENDINGAME))
-	{
-		bool bNetwork = gEnv->pNetwork->HasNetworkConnectivity();
-		m_pCurrentFlashMenuScreen->CheckedInvoke("setNetwork", bNetwork);
-	}
 }
 
 //-----------------------------------------------------------------------------------------------------

--- a/Code/CryGame/Menus/FlashMenuObject.h
+++ b/Code/CryGame/Menus/FlashMenuObject.h
@@ -268,6 +268,7 @@ private:
 	void MP_ResetProgress	(int iProgress);
 
 	void CloseWaitingScreen();
+	void UpdateNetwork(float fDeltaTime);
 
 	enum ESound
 	{

--- a/Code/CryGame/Menus/FlashMenuObject.h
+++ b/Code/CryGame/Menus/FlashMenuObject.h
@@ -268,7 +268,6 @@ private:
 	void MP_ResetProgress	(int iProgress);
 
 	void CloseWaitingScreen();
-	void UpdateNetwork(float fDeltaTime);
 
 	enum ESound
 	{

--- a/Code/CryMP/Client/ServerBrowser.cpp
+++ b/Code/CryMP/Client/ServerBrowser.cpp
@@ -309,7 +309,7 @@ void ServerBrowser::QueryClientPublicAddress()
 
 	gClient->HttpGet(url, [this](HTTPClientResult& result)
 	{
-		this->OnPublicAddress(result);
+		m_lastRequestSucceeded = this->OnPublicAddress(result);
 	});
 }
 
@@ -352,9 +352,12 @@ void ServerBrowser::Update()
 
 			m_pendingQueryCount--;
 
+			const bool success = result.error.empty();
+			m_lastRequestSucceeded = success;
+
 			if (m_pListener)
 			{
-				if (result.error.empty())
+				if (success)
 				{
 					OnServerList(result, master);
 				}
@@ -386,9 +389,12 @@ void ServerBrowser::UpdateServerInfo(int id)
 
 	gClient->HttpGet(url, [id, this](HTTPClientResult& result)
 	{
+		const bool success = result.error.empty();
+		m_lastRequestSucceeded = success;
+
 		if (m_pListener)
 		{
-			if (result.error.empty())
+			if (success)
 			{
 				if (OnServerInfo(result, id))
 				{

--- a/Code/CryMP/Client/ServerBrowser.cpp
+++ b/Code/CryMP/Client/ServerBrowser.cpp
@@ -171,6 +171,11 @@ bool ServerBrowser::OnPublicAddress(HTTPClientResult & result)
 {
 	CryLog("[CryMP] Public address (%d): %s", result.code, result.response.c_str());
 
+	if (!result.error.empty())
+	{
+		return false;
+	}
+
 	try
 	{
 		const json publicAddress = json::parse(result.response);

--- a/Code/CryMP/Client/ServerBrowser.h
+++ b/Code/CryMP/Client/ServerBrowser.h
@@ -18,6 +18,7 @@ class ServerBrowser : public IServerBrowser
 
 	unsigned int m_pendingQueryCount = 0;
 	unsigned int m_contract = 0;
+	bool m_lastRequestSucceeded = false;
 
 	bool OnPublicAddress(HTTPClientResult & result);
 	bool OnServerList(HTTPClientResult & result, const std::string & master);
@@ -28,6 +29,8 @@ public:
 	~ServerBrowser();
 
 	void QueryClientPublicAddress();
+
+	bool LastRequestSucceeded() const { return m_lastRequestSucceeded; }
 
 	// INetworkInterface
 	bool IsAvailable() const override;


### PR DESCRIPTION
~~Remove `CFlashMenuObject::UpdateNetwork` function, which calls `setNetwork` Flash function on frame. Does it actually do something other than showing no connection symbol in multiplayer lobby? @griseraner~~

Update: Use our own `ServerBrowser::LastRequestSucceeded` instead of problematic `INetwork::HasNetworkConnectivity`.

This fixes no connection symbol always shown in multiplayer lobby under Linux :penguin:, where `INetwork::HasNetworkConnectivity` always returns false when there's no recent network channel activity. In this case, it does some questionable checks of network adapters via Windows API. Definitely not something we want in main thread.

`INetwork::HasNetworkConnectivity` is also called on frame in `CHUD::OnPostUpdate`, but that one should be fine because it's called only in-game and only when `gEnv->bMultiplayer` is true. Therefore, network channel activity is there and it returns quickly without calling potentially blocking Windows API functions.

Thanks to Furyaner for pointing out that `INetwork::HasNetworkConnectivity` is the culprit here. :slightly_smiling_face: