### PR TITLE
Add HookAdapterInfo memory patches from c1-launcher

### DIFF
--- a/Code/Launcher/Launcher.cpp
+++ b/Code/Launcher/Launcher.cpp
@@ -22,6 +22,38 @@
 
 #include "config.h"
 
+static void LogBytes(const char* message, std::size_t bytes)
+{
+	const char* unit = "";
+	char units[6][2] = { "K", "M", "G", "T", "P", "E" };
+
+	for (int i = 0; i < 6 && bytes >= 1024; i++)
+	{
+		unit = units[i];
+		bytes /= 1024;
+	}
+
+	CryLogAlways("%s%zu%s", message, bytes, unit);
+}
+
+static void OnD3D9Info(MemoryPatch::CryRenderD3D9::AdapterInfo* info)
+{
+	CryLogAlways("D3D9 Adapter: %s", info->description);
+	CryLogAlways("D3D9 Adapter: PCI %04x:%04x (rev %02x)", info->vendor_id, info->device_id, info->revision);
+
+	// no memory info available
+}
+
+static void OnD3D10Info(MemoryPatch::CryRenderD3D10::AdapterInfo* info)
+{
+	CryLogAlways("D3D10 Adapter: %ls", info->description);
+	CryLogAlways("D3D10 Adapter: PCI %04x:%04x (rev %02x)", info->vendor_id, info->device_id, info->revision);
+
+	LogBytes("D3D10 Adapter: Dedicated video memory = ", info->dedicated_video_memory);
+	LogBytes("D3D10 Adapter: Dedicated system memory = ", info->dedicated_system_memory);
+	LogBytes("D3D10 Adapter: Shared system memory = ", info->shared_system_memory);
+}
+
 static IScriptSystem* CreateNewScriptSystem(ISystem* pSystem, bool)
 {
 	CryLogAlways("$3[CryMP] Initializing Script System");
@@ -485,22 +517,23 @@ void Launcher::LoadEngine()
 		throw StringTools::SysErrorFormat("Failed to load the Cry3DEngine DLL!");
 	}
 
-	const bool isDX10 = !WinAPI::CmdLine::HasArg("-dx9") && (WinAPI::CmdLine::HasArg("-dx10") || WinAPI::IsVistaOrLater());
-
-	if (isDX10)
+	if (!m_params.isDedicatedServer && !WinAPI::CmdLine::HasArg("-dedicated"))
 	{
-		m_dlls.pCryRenderD3D10 = WinAPI::DLL::Load("CryRenderD3D10.dll");
-		if (!m_dlls.pCryRenderD3D10)
+		if (!WinAPI::CmdLine::HasArg("-dx9") && (WinAPI::CmdLine::HasArg("-dx10") || WinAPI::IsVistaOrLater()))
 		{
-			throw StringTools::SysErrorFormat("Failed to load the CryRenderD3D10 DLL!");
+			m_dlls.pCryRenderD3D10 = WinAPI::DLL::Load("CryRenderD3D10.dll");
+			if (!m_dlls.pCryRenderD3D10)
+			{
+				throw StringTools::SysErrorFormat("Failed to load the CryRenderD3D10 DLL!");
+			}
 		}
-	}
-	else
-	{
-		m_dlls.pCryRenderD3D9 = WinAPI::DLL::Load("CryRenderD3D9.dll");
-		if (!m_dlls.pCryRenderD3D9)
+		else
 		{
-			throw StringTools::SysErrorFormat("Failed to load the CryRenderD3D9 DLL!");
+			m_dlls.pCryRenderD3D9 = WinAPI::DLL::Load("CryRenderD3D9.dll");
+			if (!m_dlls.pCryRenderD3D9)
+			{
+				throw StringTools::SysErrorFormat("Failed to load the CryRenderD3D9 DLL!");
+			}
 		}
 	}
 }
@@ -553,12 +586,14 @@ void Launcher::PatchEngine()
 	if (m_dlls.pCryRenderD3D9)
 	{
 		MemoryPatch::CryRenderD3D9::HookWindowNameD3D9(m_dlls.pCryRenderD3D9, GAME_WINDOW_NAME);
+		MemoryPatch::CryRenderD3D9::HookAdapterInfo(m_dlls.pCryRenderD3D9, &OnD3D9Info);
 	}
 
 	if (m_dlls.pCryRenderD3D10)
 	{
 		MemoryPatch::CryRenderD3D10::FixLowRefreshRateBug(m_dlls.pCryRenderD3D10);
 		MemoryPatch::CryRenderD3D10::HookWindowNameD3D10(m_dlls.pCryRenderD3D10, GAME_WINDOW_NAME);
+		MemoryPatch::CryRenderD3D10::HookAdapterInfo(m_dlls.pCryRenderD3D10, &OnD3D10Info);
 	}
 }
 

--- a/Code/Launcher/MemoryPatch.h
+++ b/Code/Launcher/MemoryPatch.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdarg>
+#include <cstddef>
 
 struct CPUInfo;
 
@@ -22,13 +23,45 @@ namespace MemoryPatch
 
 	namespace CryRenderD3D9
 	{
+		struct AdapterInfo
+		{
+			// D3DADAPTER_IDENTIFIER9
+			char driver[512];
+			char description[512];
+			char device_name[32];
+			unsigned long driver_version_lo;
+			unsigned long driver_version_hi;
+			unsigned long vendor_id;
+			unsigned long device_id;
+			unsigned long sub_sys_id;
+			unsigned long revision;
+			// ...
+		};
+
 		void HookWindowNameD3D9(void* pCryRenderD3D9, const char* name);
+		void HookAdapterInfo(void* pCryRenderD3D9, void (*handler)(AdapterInfo* info));
 	}
 
 	namespace CryRenderD3D10
 	{
+		struct AdapterInfo
+		{
+			void* reserved;
+			// DXGI_ADAPTER_DESC
+			wchar_t description[128];
+			unsigned int vendor_id;
+			unsigned int device_id;
+			unsigned int sub_sys_id;
+			unsigned int revision;
+			std::size_t dedicated_video_memory;
+			std::size_t dedicated_system_memory;
+			std::size_t shared_system_memory;
+			// ...
+		};
+
 		void FixLowRefreshRateBug(void* pCryRenderD3D10);
 		void HookWindowNameD3D10(void* pCryRenderD3D10, const char* name);
+		void HookAdapterInfo(void* pCryRenderD3D10, void (*handler)(AdapterInfo* info));
 	}
 
 	namespace CrySystem


### PR DESCRIPTION
- Fix crash of 64-bit DX10 renderer during startup with recent nVidia drivers
- Add logging of basic GPU information:
```
Renderer initialization
D3D10 Adapter: AMD Radeon RX 480 Graphics (RADV POLARIS10)
D3D10 Adapter: PCI 1002:67df (rev 00)
D3D10 Adapter: Dedicated video memory = 8G
D3D10 Adapter: Dedicated system memory = 0
D3D10 Adapter: Shared system memory = 31G
```