### PR TITLE
Fix WinHTTP error messages

### DIFF
--- a/Code/CrySystem/Logger.cpp
+++ b/Code/CrySystem/Logger.cpp
@@ -1,5 +1,4 @@
 #include <algorithm>
-#include <cerrno>
 #include <cstring>
 
 #include "CryCommon/CrySystem/CryColorCode.h"
@@ -95,9 +94,7 @@ void Logger::OpenFile(const std::filesystem::path& filePath)
 	FileHandle file(std::fopen(filePathString.c_str(), "w"));
 	if (!file)
 	{
-		const int code = errno;
-		throw std::system_error(code, std::generic_category(),
-			"Failed to open log file: " + filePathString + ": Error code " + std::to_string(code));
+		throw StringTools::SysErrorErrnoFormat("Failed to open log file: %s", filePathString.c_str());
 	}
 
 	m_file = std::move(file);

--- a/Code/CrySystem/Logger.h
+++ b/Code/CrySystem/Logger.h
@@ -6,7 +6,6 @@
 #include <mutex>
 #include <string>
 #include <string_view>
-#include <system_error>
 #include <thread>
 #include <vector>
 

--- a/Code/Library/StringTools.cpp
+++ b/Code/Library/StringTools.cpp
@@ -1,3 +1,4 @@
+#include <cerrno>
 #include <cstdio>
 
 #include "StringTools.h"
@@ -218,4 +219,26 @@ std::system_error StringTools::SysErrorFormatV(const char* format, va_list args)
 	message += std::to_string(code);
 
 	return std::system_error(GetSysErrorCodeWithCategory(code), message);
+}
+
+std::system_error StringTools::SysErrorErrnoFormat(const char* format, ...)
+{
+	va_list args;
+	va_start(args, format);
+	std::system_error error = SysErrorErrnoFormatV(format, args);
+	va_end(args);
+
+	return error;
+}
+
+std::system_error StringTools::SysErrorErrnoFormatV(const char* format, va_list args)
+{
+	const int code = errno;
+
+	std::string message = FormatV(format, args);
+
+	message += ": Error code ";
+	message += std::to_string(code);
+
+	return std::system_error(code, std::generic_category(), message);
 }

--- a/Code/Library/StringTools.h
+++ b/Code/Library/StringTools.h
@@ -205,4 +205,7 @@ namespace StringTools
 
 	std::system_error SysErrorFormat(const char* format, ...);
 	std::system_error SysErrorFormatV(const char* format, va_list args);
+
+	std::system_error SysErrorErrnoFormat(const char* format, ...);
+	std::system_error SysErrorErrnoFormatV(const char* format, va_list args);
 }


### PR DESCRIPTION
- WinHTTP error messages are no longer "unknown error".
- Add `StringTools::SysErrorErrnoFormat`.