### PR TITLE
Fix out-of-bounds access of the CPUInfo::cores array

### DIFF
--- a/Code/CrySystem/CPUInfo.cpp
+++ b/Code/CrySystem/CPUInfo.cpp
@@ -57,7 +57,6 @@ void CPUInfo::Detect(CPUInfo* self)
 	self->coreCountAvailable = coreCount;
 	self->coreCountPhysical = coreCount;
 	self->cores[0].flags = features;
-	self->cores[0].physical = true;
 
 	CryLogAlways("%s [Count: %u] [Features:%s%s%s%s]",
 		g_cpuid.brand_string,

--- a/Code/CrySystem/CPUInfo.h
+++ b/Code/CrySystem/CPUInfo.h
@@ -32,9 +32,7 @@ struct CPUInfo
 	{
 		unsigned int reserved1[2];
 		unsigned int flags;
-		unsigned int reserved2[60];
-		bool physical;
-		unsigned int reserved3[4];
+		unsigned int reserved2[65];
 	};
 
 	Core cores[MAX_CORE_COUNT];

--- a/Code/Launcher/Launcher.cpp
+++ b/Code/Launcher/Launcher.cpp
@@ -559,6 +559,7 @@ void Launcher::PatchEngine()
 		MemoryPatch::CrySystem::AllowDX9VeryHighSpec(m_dlls.pCrySystem);
 		MemoryPatch::CrySystem::AllowMultipleInstances(m_dlls.pCrySystem);
 		MemoryPatch::CrySystem::DisableIOErrorLog(m_dlls.pCrySystem);
+		MemoryPatch::CrySystem::FixCPUInfoOverflow(m_dlls.pCrySystem);
 		MemoryPatch::CrySystem::HookCPUDetect(m_dlls.pCrySystem, &CPUInfo::Detect);
 		MemoryPatch::CrySystem::HookError(m_dlls.pCrySystem, &CrashLogger::OnEngineError);
 		//MemoryPatch::CrySystem::MakeDX9Default(m_dlls.pCrySystem);

--- a/Code/Launcher/MemoryPatch.cpp
+++ b/Code/Launcher/MemoryPatch.cpp
@@ -411,6 +411,18 @@ void MemoryPatch::CrySystem::DisableIOErrorLog(void* pCrySystem)
 }
 
 /**
+ * Prevents out-of-bounds access of the CPUInfo::cores array.
+ */
+void MemoryPatch::CrySystem::FixCPUInfoOverflow(void* pCrySystem)
+{
+#ifdef BUILD_64BIT
+	FillNop(pCrySystem, 0x3801D, 0x1A);
+#else
+	FillNop(pCrySystem, 0x4B4A0, 0x9);
+#endif
+}
+
+/**
  * Hooks CryEngine CPU detection.
  */
 void MemoryPatch::CrySystem::HookCPUDetect(void* pCrySystem, void (*handler)(CPUInfo* info))

--- a/Code/Launcher/MemoryPatch.h
+++ b/Code/Launcher/MemoryPatch.h
@@ -69,6 +69,7 @@ namespace MemoryPatch
 		void AllowDX9VeryHighSpec(void* pCrySystem);
 		void AllowMultipleInstances(void* pCrySystem);
 		void DisableIOErrorLog(void* pCrySystem);
+		void FixCPUInfoOverflow(void* pCrySystem);
 		void HookCPUDetect(void* pCrySystem, void (*handler)(CPUInfo* info));
 		void HookError(void* pCrySystem, void (*handler)(const char* format, va_list args));
 		void MakeDX9Default(void* pCrySystem);


### PR DESCRIPTION
Before physics thread is created, the `CPUInfo::cores` array is iterated without bounds checking. A certain amount of cores with some flag set is skipped. The amount is specified by the `sys_physics_CPU` cvar, which is `1` by default. After that, some value is obtained from the next suitable core. This value is then passed to a function that creates the physics thread. Funnily enough, this value is not used at all there.

`MemoryPatch::CrySystem::FixCPUInfoOverflow` removes the pointless loop iterating over `CPUInfo::cores`. The unused resulting value is forced to be zero, which is the case when `sys_physics_CPU` is higher than number of logical processors in the system.