### PR TITLE
Fix CPUID::TrimSpaces

### DIFF
--- a/Code/Library/CPUID.h
+++ b/Code/Library/CPUID.h
@@ -138,7 +138,7 @@ private:
 		{
 			if (*s != ' ')
 			{
-				end = s + 1;
+				end = begin + 1;
 			}
 
 			*begin++ = *s++;


### PR DESCRIPTION
Fix a subtle bug in `CPUID::TrimSpaces`.

### Example of the problem

- raw brand string:
```
       Intel(R) Core(TM) i3-3217U CPU @ 1.80GHz
```

- expected brand string after trimming spaces:
```
Intel(R) Core(TM) i3-3217U CPU @ 1.80GHz
```

- actual result:
```
Intel(R) Core(TM) i3-3217U CPU @ 1.80GHz1.80GHz
```