### PR TITLE
CPPAPI.AddLocalizedLabel: Use existing label for unspecified values

### DIFF
--- a/Code/CryMP/Client/ScriptBind_CPPAPI.cpp
+++ b/Code/CryMP/Client/ScriptBind_CPPAPI.cpp
@@ -515,6 +515,12 @@ int ScriptBind_CPPAPI::AddLocalizedLabel(IFunctionHandler* pH, const char* name,
 
 	label.name = name;
 
+	const LocalizationManager::Label* existingLabel = localization.FindLabel(label.name);
+	if (existingLabel)
+	{
+		label = *existingLabel;
+	}
+
 	if (params)
 	{
 		CScriptSetGetChain rootChain(params);

--- a/Code/CrySystem/LocalizationManager.cpp
+++ b/Code/CrySystem/LocalizationManager.cpp
@@ -377,7 +377,25 @@ bool LocalizationManager::Add(Label&& label, bool keepExisting)
 	}
 }
 
-std::string LocalizationManager::Localize(const std::string_view& text) const
+const LocalizationManager::Label* LocalizationManager::FindLabel(std::string_view name) const
+{
+	std::string loweredName;
+	StringTools::AppendTo(loweredName, name);
+	StringTools::ToLowerInPlace(loweredName);
+
+	return this->FindLabelImpl(loweredName);
+}
+
+const LocalizationManager::Label* LocalizationManager::FindLabel(std::wstring_view name) const
+{
+	std::string loweredName;
+	StringTools::AppendTo(loweredName, name);
+	StringTools::ToLowerInPlace(loweredName);
+
+	return this->FindLabelImpl(loweredName);
+}
+
+std::string LocalizationManager::Localize(std::string_view text) const
 {
 	const bool english = false;
 
@@ -387,7 +405,7 @@ std::string LocalizationManager::Localize(const std::string_view& text) const
 	return result;
 }
 
-std::string LocalizationManager::LocalizeEnglish(const std::string_view& text) const
+std::string LocalizationManager::LocalizeEnglish(std::string_view text) const
 {
 	const bool english = true;
 
@@ -762,23 +780,18 @@ void LocalizationManager::LocalizeDuration(int seconds, wstring& result)
 	LocalizeString(buffer, result);
 }
 
-template<typename NameStringView>
-const LocalizationManager::Label* LocalizationManager::FindLabel(NameStringView name) const
+const LocalizationManager::Label* LocalizationManager::FindLabelImpl(std::string_view loweredName) const
 {
-	if (name.length() > 0 && name[0] == '@')
+	if (loweredName.length() > 0 && loweredName[0] == '@')
 	{
-		name.remove_prefix(1);
+		loweredName.remove_prefix(1);
 	}
-
-	std::string loweredName;
-	StringTools::AppendTo(loweredName, name);
-	StringTools::ToLowerInPlace(loweredName);
 
 	// binary search
 	const auto it = std::lower_bound(m_language.labels.begin(), m_language.labels.end(), loweredName,
-		[](const Label& label, const std::string& name)
+		[](const Label& label, const std::string_view& loweredName)
 		{
-			return label.name < name;
+			return label.name < loweredName;
 		}
 	);
 

--- a/Code/CrySystem/LocalizationManager.h
+++ b/Code/CrySystem/LocalizationManager.h
@@ -60,8 +60,11 @@ public:
 
 	bool Add(Label&& label, bool keepExisting = false);
 
-	std::string Localize(const std::string_view& text) const;
-	std::string LocalizeEnglish(const std::string_view& text) const;
+	const Label* FindLabel(std::string_view name) const;
+	const Label* FindLabel(std::wstring_view name) const;
+
+	std::string Localize(std::string_view text) const;
+	std::string LocalizeEnglish(std::string_view text) const;
 
 	static std::string_view GetLanguageFromSystem();
 
@@ -111,8 +114,7 @@ public:
 	////////////////////////////////////////////////////////////////////////////////
 
 private:
-	template<typename NameStringView>
-	const Label* FindLabel(NameStringView name) const;
+	const Label* FindLabelImpl(std::string_view loweredName) const;
 
 	template<typename NameStringView, typename ResultString>
 	bool LocalizeControlCode(NameStringView name, ResultString& result) const;


### PR DESCRIPTION
Instead of having to specify all attributes of a localized label, you can now only set those you want to change and the rest will be taken from the existing label.