### PR TITLE
Free cursor in windowed mode when menu is open

### DIFF
--- a/Code/CryGame/Game.cpp
+++ b/Code/CryGame/Game.cpp
@@ -680,6 +680,61 @@ COptionsManager* CGame::GetOptions() const
 	return m_pOptionsManager;
 }
 
+bool CGame::IsMenuActive() const
+{
+	return GetMenu() && GetMenu()->IsActive();
+}
+
+bool CGame::ShowMousePointer(bool show)
+{
+	if (show == m_isMousePointerVisible)
+	{
+		return false;
+	}
+
+	if (m_isMousePointerVisible)
+	{
+		// hide mouse cursor
+
+		if (gEnv->pHardwareMouse)
+		{
+			gEnv->pHardwareMouse->DecrementCounter();
+		}
+
+		m_isMousePointerVisible = false;
+	}
+	else
+	{
+		// show mouse cursor
+
+		if (gEnv->pHardwareMouse)
+		{
+			gEnv->pHardwareMouse->IncrementCounter();
+		}
+
+		m_isMousePointerVisible = true;
+	}
+
+	return true;
+}
+
+void CGame::ConfineCursor(bool confine)
+{
+	if (gEnv->pHardwareMouse)
+	{
+		int fullscreen = 0;
+		if (ICVar* pFullscreenCVar = gEnv->pConsole->GetCVar("r_Fullscreen"))
+		{
+			fullscreen = pFullscreenCVar->GetIVal();
+		}
+
+		if (!fullscreen)
+		{
+			gEnv->pHardwareMouse->ConfineCursor(confine);
+		}
+	}
+}
+
 void CGame::LoadActionMaps(const char* filename)
 {
 	if (g_pGame->GetIGameFramework()->IsGameStarted())

--- a/Code/CryGame/Game.h
+++ b/Code/CryGame/Game.h
@@ -188,38 +188,10 @@ public:
 
   ILINE SCVars *GetCVars() {return m_pCVars;}
 
-	bool ShowMousePointer(bool show)
-	{
-		if (show == m_isMousePointerVisible)
-		{
-			return false;
-		}
 
-		if (m_isMousePointerVisible)
-		{
-			// hide mouse cursor
-
-			if (gEnv->pHardwareMouse)
-			{
-				gEnv->pHardwareMouse->DecrementCounter();
-			}
-
-			m_isMousePointerVisible = false;
-		}
-		else
-		{
-			// show mouse cursor
-
-			if (gEnv->pHardwareMouse)
-			{
-				gEnv->pHardwareMouse->IncrementCounter();
-			}
-
-			m_isMousePointerVisible = true;
-		}
-
-		return true;
-	}
+    bool IsMenuActive() const;
+    bool ShowMousePointer(bool show);
+    void ConfineCursor(bool confine);
 
 	bool IsMousePointerVisible() const
 	{

--- a/Code/CryGame/Menus/FlashMenuObject.cpp
+++ b/Code/CryGame/Menus/FlashMenuObject.cpp
@@ -2755,6 +2755,8 @@ void CFlashMenuObject::InitStartMenu()
 	SetAntiAliasingModes();
 
 	SetProfile();
+
+	g_pGame->ConfineCursor(false);
 }
 
 //-----------------------------------------------------------------------------------------------------
@@ -2774,6 +2776,8 @@ void CFlashMenuObject::DestroyStartMenu()
 
 	m_bIgnoreEsc = false;
 	m_bDestroyStartMenuPending = false;
+
+	g_pGame->ConfineCursor(true);
 }
 
 //-----------------------------------------------------------------------------------------------------
@@ -2791,6 +2795,8 @@ void CFlashMenuObject::InitIngameMenu()
 	if (!m_apFlashMenuScreens[MENUSCREEN_FRONTENDINGAME]->IsLoaded())
 	{
 		g_pGame->ShowMousePointer(true);
+
+		g_pGame->ConfineCursor(false);
 
 #ifdef CRYSIS_BETA
 		m_apFlashMenuScreens[MENUSCREEN_FRONTENDINGAME]->Load("Libs/UI/Menus_IngameMenu_Beta.gfx");
@@ -2871,6 +2877,8 @@ void CFlashMenuObject::DestroyIngameMenu()
 	}
 	if (g_pGame->GetIGameFramework()->IsGameStarted())
 		ReloadHUDMovies();
+
+	g_pGame->ConfineCursor(true);
 }
 
 //-----------------------------------------------------------------------------------------------------

--- a/Code/CrySystem/GameWindow.cpp
+++ b/Code/CrySystem/GameWindow.cpp
@@ -19,6 +19,16 @@ static LRESULT CALLBACK WindowProc(HWND window, UINT msg, WPARAM wParam, LPARAM 
 {
 	switch (msg)
 	{
+		case WM_PAINT:
+		{
+			if (g_pGame)
+			{
+				//Fixes cursor moving outside window (after you alt tab to another window
+				//and click on show desktop, then open crysis window)
+				g_pGame->ConfineCursor(!g_pGame->IsMenuActive());
+			}
+			break;
+		}
 		case WM_MOVE:  // 0x3
 		{
 			int x = GET_X_LPARAM(lParam);
@@ -34,6 +44,11 @@ static LRESULT CALLBACK WindowProc(HWND window, UINT msg, WPARAM wParam, LPARAM 
 			int h = GET_Y_LPARAM(lParam);
 
 			gEnv->pSystem->GetISystemEventDispatcher()->OnSystemEvent(ESYSTEM_EVENT_RESIZE, w, h);
+
+			if (g_pGame)
+			{
+				g_pGame->ConfineCursor(!g_pGame->IsMenuActive());
+			}
 
 			break;
 		}
@@ -184,7 +199,7 @@ static LRESULT CALLBACK WindowProc(HWND window, UINT msg, WPARAM wParam, LPARAM 
 		case WM_EXITMENULOOP:  // 0x212
 		case WM_EXITSIZEMOVE:  // 0x232
 		{
-			if (g_pGame && !g_pGame->GetMenu())
+			if (g_pGame && !g_pGame->IsMenuActive())
 			{
 				g_pGame->ShowMousePointer(false);
 			}
@@ -197,12 +212,23 @@ static LRESULT CALLBACK WindowProc(HWND window, UINT msg, WPARAM wParam, LPARAM 
 		}
 		case EVENT_SYSTEM_MENUPOPUPSTART:
 		{
-			gEnv->pSystem->GetISystemEventDispatcher()->OnSystemEvent(ESYSTEM_EVENT_CHANGE_FOCUS, 0, 0);
+			//gEnv->pSystem->GetISystemEventDispatcher()->OnSystemEvent(ESYSTEM_EVENT_CHANGE_FOCUS, 0, 0);
+
+			if (g_pGame)
+			{
+				g_pGame->ConfineCursor(false);
+			}
+
 			break;
 		}
 		case EVENT_SYSTEM_MENUPOPUPEND:
 		{
-			gEnv->pSystem->GetISystemEventDispatcher()->OnSystemEvent(ESYSTEM_EVENT_CHANGE_FOCUS, 1, 0);
+			//gEnv->pSystem->GetISystemEventDispatcher()->OnSystemEvent(ESYSTEM_EVENT_CHANGE_FOCUS, 1, 0);
+
+			if (g_pGame)
+			{
+				g_pGame->ConfineCursor(!g_pGame->IsMenuActive());
+			}
 			break;
 		}
 		default:


### PR DESCRIPTION
*Fix a potential cursor bug
*Fix cursor appearing after you alt-tab out of windowed mode, then clicking "show desktop" and maximizing crysis window