### PR TITLE
Remove fxopen and refactor OptionsManager

### DIFF
--- a/Code/CryCommon/Cry3DEngine/I3DEngine.h
+++ b/Code/CryCommon/Cry3DEngine/I3DEngine.h
@@ -33,10 +33,12 @@
 #include "CryEngineDecalInfo.h" 
 #include "IStatObj.h"
 #include "CryCommon/CrySystem/IProcess.h"
+#include "CryCommon/CrySystem/ISystem.h"
 #include "IMaterial.h"
 #include "ISurfaceType.h"
 #include "CryCommon/CryEntitySystem/IEntityRenderState.h"
 #include "CryCommon/CryCore/CryArray.h"
+#include "CryCommon/CryCore/smartptr.h"
 // !!! Do not add any headers here !!!
 
 struct ISystem;

--- a/Code/CryCommon/CryAction/IPlayerProfiles.h
+++ b/Code/CryCommon/CryAction/IPlayerProfiles.h
@@ -13,6 +13,8 @@
 
 struct IPlayerProfile;
 struct IActionMap;
+struct ILoadGame;
+struct ISaveGame;
 
 struct ISaveGameThumbnail
 {

--- a/Code/CryCommon/CryCore/TArray.h
+++ b/Code/CryCommon/CryCore/TArray.h
@@ -5,8 +5,6 @@
 #ifndef __TARRAY_H__
 #define __TARRAY_H__
 
-#include "CryCommon/CrySystem/ICryPak.h"  // impl of fxopen
-
 #ifndef CLAMP
 #define CLAMP(X, mn, mx) ((X)<(mn) ? (mn) : ((X)<(mx) ? (X) : (mx)))
 #endif
@@ -443,26 +441,6 @@ public:
   {
 //    memset(&m_pElements[n],0,sizeof(T));
     _Remove(n, 1);
-  }
-
-  void Load(const char * file_name)
-  {
-    Clear();
-    FILE * f = fxopen(file_name, "rb");
-    if(!f)
-      return;
-    
-    int size = 0;
-    fread(&size, 4, 1, f);
-    
-    while(!feof(f) && sizeof(T)==size)
-    {
-      T tmp;
-      if(fread(&tmp, 1, sizeof(T), f) == sizeof(T))
-        AddElem(tmp);
-    }
-    
-    fclose(f);
   }
 
 

--- a/Code/CryCommon/CrySystem/CryFile.h
+++ b/Code/CryCommon/CrySystem/CryFile.h
@@ -17,7 +17,7 @@
 #define __cryfile_h__
 #pragma once
 
-#include "ISystem.h"
+#include "gEnv.h"
 #include "ICryPak.h"
 
 //////////////////////////////////////////////////////////////////////////
@@ -103,19 +103,30 @@ public:
 	virtual size_t ReadRaw( void *lpBuf, size_t nSize );
 	//! Template version, for automatic size support.
 	template<class T>
-		inline size_t ReadTypeRaw( T *pDest, size_t nCount = 1 )
-		{
-			return ReadRaw( pDest, sizeof(T)*nCount );
-		}
+	size_t ReadTypeRaw( T *pDest, size_t nCount = 1 )
+	{
+		return ReadRaw( pDest, sizeof(T)*nCount );
+	}
 
 	//! Automatic endian-swapping version.
 	template<class T>
-		inline size_t ReadType( T *pDest, size_t nCount = 1 )
-		{
-			size_t nRead = ReadRaw( pDest, sizeof(T)*nCount );
-			SwapEndian(pDest, nCount);
-			return nRead;
-		}
+	size_t ReadType( T *pDest, size_t nCount = 1 )
+	{
+		size_t nRead = ReadRaw( pDest, sizeof(T)*nCount );
+		SwapEndian(pDest, nCount);
+		return nRead;
+	}
+
+	void Puts(const char* line)
+	{
+		m_pIPak->FPrintf(m_file, "%s\n", line);
+	}
+
+	template<class... Args>
+	int FPrintf(const char* format, Args... args)
+	{
+		return m_pIPak->FPrintf(m_file, format, args...);
+	}
 
 	//! Retrieves the length of the file.
 	virtual size_t GetLength();
@@ -232,21 +243,12 @@ inline size_t CCryFile::GetLength()
 	return size;
 }
 
-#ifdef WIN64
-#pragma warning( push )									//AMD Port
-#pragma warning( disable : 4267 )
-#endif
-
 //////////////////////////////////////////////////////////////////////////
 inline size_t CCryFile::Seek( size_t seek, int mode )
 {
 	assert( m_file );
-	return m_pIPak->FSeek( m_file,seek,mode );
+	return m_pIPak->FSeek( m_file,static_cast<long>(seek),mode );
 }
-
-#ifdef WIN64
-#pragma warning( pop )									//AMD Port
-#endif
 
 //////////////////////////////////////////////////////////////////////////
 inline void CCryFile::SeekToBegin()

--- a/Code/CryCommon/CrySystem/ICryPak.h
+++ b/Code/CryCommon/CrySystem/ICryPak.h
@@ -13,6 +13,7 @@
 #include <cstdint>
 #include <vector>  // for smartptr.h
 
+#include "CryCommon/CryCore/platform.h"  // PRINTF_PARAMS
 #include "CryCommon/CryCore/smartptr.h"
 
 struct IResourceList; 
@@ -503,46 +504,3 @@ struct IResourceList : public _reference_target_t
 //////////////////////////////////////////////////////////////////////////
 #include "CryPath.h"
 #include "CryFile.h"
-
-//////////////////////////////////////////////////////////////////////
-
-//! Everybody should use fxopen instead of fopen
-//! so it will work both on PC and XBox
-inline FILE * fxopen(const char *file, const char *mode)
-{
-	//SetFileAttributes(file,FILE_ATTRIBUTE_ARCHIVE);
-	//	FILE *pFile = fopen("C:/MasterCD/usedfiles.txt","a");
-	//	if (pFile)
-	//	{
-	//		fprintf(pFile,"%s\n",file);
-	//		fclose(pFile);
-	//	}
-
-#if defined(LINUX)
-	char adjustedName[MAX_PATH];
-	bool createFlag = false;
-	if (strchr(mode, 'w') || strchr(mode, 'a'))
-		createFlag = true;
-	GetFilenameNoCase(file, adjustedName, createFlag);
-	return fopen(adjustedName, mode);
-#else
-	// This is on windows.
-	if (gEnv && gEnv->pCryPak)
-	{
-		bool bWriteAccess = false;
-		for (const char *s = mode; *s; s++) { if (*s == 'w' || *s == 'W' || *s == 'a' || *s == 'A' || *s == '+') { bWriteAccess = true; break; }; }
-		int nAdjustFlags = ICryPak::FLAGS_NO_MASTER_FOLDER_MAPPING;
-		if (bWriteAccess)
-			nAdjustFlags |= ICryPak::FLAGS_FOR_WRITING;
-		char path[_MAX_PATH];
-		const char* szAdjustedPath = gEnv->pCryPak->AdjustFileName(file,path,nAdjustFlags);
-		return fopen(szAdjustedPath,mode);
-	}
-	else
-	{
-		return 0;
-	}
-#endif
-}
-
-//////////////////////////////////////////////////////////////////////////

--- a/Code/CryGame/Menus/FlashMenuObjectSingleplayer.cpp
+++ b/Code/CryGame/Menus/FlashMenuObjectSingleplayer.cpp
@@ -12,6 +12,7 @@ History:
 
 *************************************************************************/
 #include "CryCommon/CrySystem/ISystem.h"
+#include "CryCommon/CrySystem/ICryPak.h"
 
 #include "FlashMenuObject.h"
 #include "FlashMenuScreen.h"
@@ -22,6 +23,7 @@ History:
 #include "CryCommon/CrySoundSystem/ISound.h"
 #include "CryCommon/CryRenderer/IRenderer.h"
 #include "CryGame/Game.h"
+#include "CryGame/GameCVars.h"
 #include "OptionsManager.h"
 #include <time.h>
 

--- a/Code/CryGame/Menus/OptionsManager.h
+++ b/Code/CryGame/Menus/OptionsManager.h
@@ -12,19 +12,19 @@ History:
 - 03/2007: Created by Jan Müller
 
 *************************************************************************/
-#ifndef __OPTIONS_MANAGER_H__
-#define __OPTIONS_MANAGER_H__
-
 #pragma once
 
+#include <map>
+#include <string>
+#include <string_view>
+
 #include "CryCommon/CrySystem/IConsole.h"
-#include "CryCommon/CryAction/IGameFramework.h"
-#include "CryGame/GameCVars.h"
 
 //-----------------------------------------------------------------------------------------------------
 
-class CGameFlashAnimation;
+class CCryFile;
 class CFlashMenuScreen;
+struct IPlayerProfileManager;
 
 //-----------------------------------------------------------------------------------------------------
 
@@ -40,12 +40,9 @@ enum ECrysisProfileColor
 
 //-----------------------------------------------------------------------------------------------------
 
-class COptionsManager : public ICVarDumpSink
+class COptionsManager
 {
-
-	typedef void (COptionsManager::*OpFuncPtr) (const char*);
-
-public :
+public:
 
 	~COptionsManager() 
 	{
@@ -59,14 +56,10 @@ public :
 		return sp_optionsManager;
 	}
 
-	ILINE IPlayerProfileManager *GetProfileManager() { return m_pPlayerProfileManager; }
-	ILINE bool IsFirstStart() { return m_firstStart; }
+	IPlayerProfileManager* GetProfileManager() { return m_pPlayerProfileManager; }
+	bool IsFirstStart() { return m_firstStart; }
 
 	ECrysisProfileColor GetCrysisProfileColor();
-
-	//ICVarDumpSink
-	virtual void OnElementFound(ICVar *pCVar);
-	//~ICVarDumpSink
 
 	//flash system
 	bool HandleFSCommand(const char *strCommand,const char *strArgs);
@@ -94,22 +87,24 @@ public :
 	bool IgnoreProfile();
 	bool WriteGameCfg();
 	void SetVideoMode(const char* params);
+	void SetAntiAliasingMode(const char* params);
+	void SetDifficulty(const char* params);
+	void PBClient(const char* params);
 	void AutoDetectHardware(const char* params);
 	void SystemConfigChanged(bool silent = false);
 	//~profile system
 
 private:
+	bool HandleSpecialCommand(std::string_view command, const char* args);
+
 	struct CCVarSink : public ICVarDumpSink
 	{
-		CCVarSink(COptionsManager* pMgr, FILE* pFile)
-		{
-			m_pOptionsManager = pMgr;
-			m_pFile = pFile;
-		}
+		const COptionsManager* self;
+		CCryFile& file;
 
-		void OnElementFound(ICVar *pCVar);
-		COptionsManager* m_pOptionsManager;
-		FILE* m_pFile;
+		explicit CCVarSink(const COptionsManager* self, CCryFile& file) : self(self), file(file) {}
+
+		void OnElementFound(ICVar* pCVar) override;
 	};
 
 	COptionsManager();
@@ -117,29 +112,13 @@ private:
 
 	struct SOptionEntry
 	{
-		string name;
-		bool   bWriteToConfig;
-
-		SOptionEntry() : bWriteToConfig(false) {}
-		SOptionEntry(const string& name, bool bWriteToConfig) : name(name), bWriteToConfig(bWriteToConfig) {}
-		SOptionEntry(const char* name, bool bWriteToConfig) : name(name), bWriteToConfig(bWriteToConfig) {}
+		std::string name;
+		bool writeToConfig = false;
 	};
 
-	std::map<string, SOptionEntry> m_profileOptions;
+	std::map<std::string, SOptionEntry, std::less<void>> m_profileOptions;
 
 	ECrysisProfileColor m_eCrysisProfileColor;
-
-	//************ OPTION FUNCTIONS ************
-	void SetAntiAliasingMode(const char* params);
-	void SetDifficulty(const char* params);
-	void PBClient(const char* params);
-	//initialize option-functions
-	void InitOpFuncMap();
-	//option-function mapper
-	typedef std::map<string, OpFuncPtr> TOpFuncMap;
-	TOpFuncMap	m_opFuncMap;
-	typedef TOpFuncMap::iterator TOpFuncMapIt;
-	//******************************************
 
 	void SetCrysisProfileColor(const char *szValue);
 	CFlashMenuScreen * GetCurrentMenu();
@@ -153,9 +132,5 @@ private:
 	bool m_firstStart;
 
 };
-
-//-----------------------------------------------------------------------------------------------------
-
-#endif
 
 //-----------------------------------------------------------------------------------------------------

--- a/Code/CryGame/Nodes/FlowFadeNode.cpp
+++ b/Code/CryGame/Nodes/FlowFadeNode.cpp
@@ -3,6 +3,7 @@
 // Copyright (C) Crytek GmbH, 2001-2008.
 // -------------------------------------------------------------------------
 #include "CryCommon/CrySystem/ISystem.h"
+#include "CryCommon/CrySystem/ICryPak.h"
 #include "CryGame/Game.h"
 #include "CryGame/GameCVars.h"
 #include "CryGame/Items/Item.h"

--- a/Code/CryGame/SPAnalyst.cpp
+++ b/Code/CryGame/SPAnalyst.cpp
@@ -15,6 +15,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #include "CryCommon/CrySystem/ISystem.h"
+#include "CryCommon/CrySystem/ICryPak.h"
 #include "SPAnalyst.h"
 
 #include "CryCommon/CryNetwork/ISerialize.h"

--- a/Code/CryGame/ScriptUtils.cpp
+++ b/Code/CryGame/ScriptUtils.cpp
@@ -152,20 +152,3 @@ bool SetLuaVarRecursive(const char *sKey, const ScriptAnyValue &newValue) {
 	// Delete copy and return
 	return true;
 }
-
-//-------------------------------------------------------------------------
-
-// Dump a Lua table as a string
-bool DumpLuaTable( IScriptTable * table, FILE * file, string &result ) {
-	
-	IScriptSystem *pScript = gEnv->pScriptSystem;
-	char *str = NULL; 		
-	HSCRIPTFUNCTION f = pScript->GetFunctionPtr("DumpTableAsLuaString");
-	//ScriptAnyValue val;
-	//gEnv->pScriptSystem->GetGlobalAny("DumpTableAsLuaString",val);
-	//SmartScriptFunction fun( pScript, pScript->GetFunctionPtr("DumpTableAsLuaString") );
-	bool success = Script::CallReturn( pScript, f, table, "Tweaks.TweaksSave", str );
-	result = str;
-	pScript->ReleaseFunc(f);
-	return success;
-}

--- a/Code/CryGame/ScriptUtils.h
+++ b/Code/CryGame/ScriptUtils.h
@@ -11,9 +11,6 @@ History:
 
 *************************************************************************/
 
-#ifndef __SCRIPTUTILS_H__
-#define __SCRIPTUTILS_H__
-
 #pragma once
 
 #include "CryCommon/CryScriptSystem/IScriptSystem.h"
@@ -76,9 +73,3 @@ inline bool GetLuaVarRecursive(const char *sKey, ScriptAnyValue &result,const Sc
 	}
 	return bRet;
 }
-
-// Dump a table out to a file stream as LUA code
-bool DumpLuaTable( IScriptTable * table, FILE * file, string &str);
-
-
-#endif __SCRIPTUTILS_H__

--- a/Code/CryMP/Client/EngineCache.cpp
+++ b/Code/CryMP/Client/EngineCache.cpp
@@ -2,6 +2,7 @@
 #include <vector>
 
 #include "CryCommon/CrySystem/ISystem.h"
+#include "CryCommon/CrySystem/ICryPak.h"
 #include "CryCommon/CrySystem/IConsole.h"
 #include "CryCommon/Cry3DEngine/I3DEngine.h"
 #include "CryCommon/CryAnimation/ICryAnimation.h"

--- a/Code/CryMP/Client/ScriptBind_CPPAPI.cpp
+++ b/Code/CryMP/Client/ScriptBind_CPPAPI.cpp
@@ -1,4 +1,5 @@
 #include "CryCommon/CrySystem/ISystem.h"
+#include "CryCommon/CrySystem/ICryPak.h"
 #include "CryCommon/CrySystem/IConsole.h"
 #include "CryCommon/Cry3DEngine/IMaterial.h"
 #include "CryCommon/CryEntitySystem/IEntitySystem.h"


### PR DESCRIPTION
- Remove problematic `fxopen`. It bypasses `ICryPak::FOpen`, which is no-no.
- Remove unused `TArray::Load`. CryPak is not a dependency of `TArray` anymore.
- Reduce unnecessary includes and fix missing ones.
- Add `CCryFile::Puts` and `CCryFile::FPrintf`.
- Refactor `COptionsManager` after removing `fxopen` from there.