### PR TITLE
Fix LAN lobby unable to find any servers

### DIFF
--- a/Code/Launcher/Launcher.cpp
+++ b/Code/Launcher/Launcher.cpp
@@ -594,6 +594,7 @@ void Launcher::PatchEngine()
 		MemoryPatch::CryNetwork::EnablePreordered(m_dlls.pCryNetwork);
 		MemoryPatch::CryNetwork::FixFileCheckCrash(m_dlls.pCryNetwork);
 		MemoryPatch::CryNetwork::FixInternetConnect(m_dlls.pCryNetwork);
+		MemoryPatch::CryNetwork::FixLanServerBrowser(m_dlls.pCryNetwork);
 	}
 
 	if (m_dlls.pCrySystem)

--- a/Code/Launcher/MemoryPatch.cpp
+++ b/Code/Launcher/MemoryPatch.cpp
@@ -161,6 +161,28 @@ void MemoryPatch::CryNetwork::FixInternetConnect(void* pCryNetwork)
 #endif
 }
 
+/**
+ * Fixes LAN server browser unable to find any servers when GameSpy is only used for LAN lobby.
+ */
+void MemoryPatch::CryNetwork::FixLanServerBrowser(void* pCryNetwork)
+{
+#ifdef BUILD_64BIT
+	const unsigned char code[] = {
+		0x40, 0x3A, 0xF8,  // cmp dil, al
+	};
+#else
+	const unsigned char code[] = {
+		0x38, 0x5D, 0x08,  // cmp byte ptr ss:[ebp+0x8], bl
+	};
+#endif
+
+#ifdef BUILD_64BIT
+	FillMem(pCryNetwork, 0x110D8A, &code, sizeof(code));
+#else
+	FillMem(pCryNetwork, 0x53936, &code, sizeof(code));
+#endif
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // CryRenderD3D9
 ////////////////////////////////////////////////////////////////////////////////

--- a/Code/Launcher/MemoryPatch.h
+++ b/Code/Launcher/MemoryPatch.h
@@ -19,6 +19,7 @@ namespace MemoryPatch
 		void EnablePreordered(void* pCryNetwork);
 		void FixFileCheckCrash(void* pCryNetwork);
 		void FixInternetConnect(void* pCryNetwork);
+		void FixLanServerBrowser(void* pCryNetwork);
 	}
 
 	namespace CryRenderD3D9


### PR DESCRIPTION
This PR fixes incorrect handling of a bool flag indicating server browser type (Internet or LAN) inside CryNetwork. Normally, it's not a problem (or is it?), but we don't initialize GameSpy in Internet mode at all and use it only in LAN lobby.