### PR TITLE
Fix trailing slash in Launcher::InitWorkingDirectory

### DIFF
--- a/Code/Launcher/Launcher.cpp
+++ b/Code/Launcher/Launcher.cpp
@@ -480,7 +480,13 @@ void Launcher::InitWorkingDirectory()
 	}
 
 	// sanitize the path
-	dir = std::filesystem::canonical(dir);
+	dir = dir.lexically_normal();
+
+	// remove trailing slash
+	if (!dir.has_filename())
+	{
+		dir = dir.parent_path();
+	}
 
 #ifdef BUILD_64BIT
 	constexpr std::string_view BIN_DIR = "Bin64";


### PR DESCRIPTION
If a `std::filesystem::path` contains a trailing slash, then `filename()` is empty. This caused problems in `Launcher::InitWorkingDirectory`.