### PR TITLE
Fix MemoryPatch::CryAISystem::AllowMultiplayerAI + small refactoring

### DIFF
--- a/Code/Launcher/Launcher.cpp
+++ b/Code/Launcher/Launcher.cpp
@@ -839,7 +839,7 @@ void Launcher::PatchEngine()
 
 	if (m_dlls.pCryAISystem)
 	{
-		MemoryPatch::CryAISystem::DisableMPChecksInAI(m_dlls.pCryAISystem);
+		MemoryPatch::CryAISystem::AllowMultiplayerAI(m_dlls.pCryAISystem);
 	}
 
 	if (m_dlls.pCryNetwork)
@@ -862,7 +862,7 @@ void Launcher::PatchEngine()
 		//MemoryPatch::CrySystem::MakeDX9Default(m_dlls.pCrySystem);
 		MemoryPatch::CrySystem::RemoveSecuROM(m_dlls.pCrySystem);
 		MemoryPatch::CrySystem::UnhandledExceptions(m_dlls.pCrySystem);
-		MemoryPatch::CrySystem::EnablePhysicsThread(m_dlls.pCrySystem);
+		MemoryPatch::CrySystem::EnableServerPhysicsThread(m_dlls.pCrySystem);
 
 		if (!WinAPI::CmdLine::HasArg("-oldss"))
 		{

--- a/Code/Launcher/Launcher.h
+++ b/Code/Launcher/Launcher.h
@@ -6,7 +6,6 @@ class CGame;
 
 class Launcher final : public ISystemUserCallback
 {
-public:
 	struct DLLs
 	{
 		// do not try to unload these DLLs as it might crash
@@ -20,7 +19,6 @@ public:
 		void* pFmodEx = nullptr;
 	};
 
-private:
 	DLLs m_dlls;
 	SSystemInitParams m_params;
 

--- a/Code/Launcher/MemoryPatch.h
+++ b/Code/Launcher/MemoryPatch.h
@@ -16,7 +16,7 @@ namespace MemoryPatch
 
 	namespace CryAISystem
 	{
-		void DisableMPChecksInAI(void* pCryAISystem);
+		void AllowMultiplayerAI(void* pCryAISystem);
 	}
 
 	namespace CryNetwork
@@ -84,7 +84,7 @@ namespace MemoryPatch
 		void MakeDX9Default(void* pCrySystem);
 		void RemoveSecuROM(void* pCrySystem);
 		void UnhandledExceptions(void* pCrySystem);
-		void EnablePhysicsThread(void* pCrySystem);
+		void EnableServerPhysicsThread(void* pCrySystem);
 	}
 
 	namespace FMODEx


### PR DESCRIPTION
- Fix the CryAISystem patch to enable AI in multiplayer. It did the opposite and disabled it everywhere. Close #179
- Small refactoring.
