### PR TITLE
Remove broken WinHTTP timeout

### DIFF
--- a/Code/CryMP/Client/FileDownloader.cpp
+++ b/Code/CryMP/Client/FileDownloader.cpp
@@ -84,7 +84,6 @@ struct FileDownloaderTask : public IExecutorTask
 				request.url,
 				{},  // data
 				{},  // headers
-				request.timeout,
 				[this, &file](uint64_t contentLength, const WinAPI::HTTPRequestReader & reader)
 				{
 					// content length is zero if not provided by the server

--- a/Code/CryMP/Client/FileDownloader.h
+++ b/Code/CryMP/Client/FileDownloader.h
@@ -32,7 +32,6 @@ struct FileDownloaderRequest
 	std::filesystem::path filePath;
 	std::function<bool(FileDownloaderProgress&)> onProgress;  // return false to cancel download
 	std::function<void(FileDownloaderResult&)> onComplete;
-	int timeout = 4000;
 };
 
 class FileDownloader

--- a/Code/CryMP/Client/ScriptBind_CPPAPI.cpp
+++ b/Code/CryMP/Client/ScriptBind_CPPAPI.cpp
@@ -226,18 +226,15 @@ int ScriptBind_CPPAPI::Request(IFunctionHandler *pH, SmartScriptTable params, HS
 		const char *method = "GET";
 		const char *body = "";
 		SmartScriptTable headers;
-		int timeout = 4000;
 
 		chain.GetValue("url", url);
 		chain.GetValue("method", method);
 		chain.GetValue("body", body);
 		chain.GetValue("headers", headers);
-		chain.GetValue("timeout", timeout);
 
 		request.url = url;
 		request.method = method;
 		request.data = body;
-		request.timeout = timeout;
 
 		if (headers)
 		{

--- a/Code/CryMP/Common/HTTPClient.cpp
+++ b/Code/CryMP/Common/HTTPClient.cpp
@@ -22,7 +22,6 @@ struct HTTPClientTask : public IExecutorTask
 				request.url,
 				request.data,
 				request.headers,
-				request.timeout,
 				[this](uint64_t contentLength, const WinAPI::HTTPRequestReader & reader)
 				{
 					// content length is zero if not provided by the server

--- a/Code/CryMP/Common/HTTPClient.h
+++ b/Code/CryMP/Common/HTTPClient.h
@@ -23,7 +23,6 @@ struct HTTPClientRequest
 	std::string data;
 	std::map<std::string, std::string> headers;
 	std::function<void(HTTPClientResult&)> callback;
-	int timeout = 4000;
 };
 
 class HTTPClient

--- a/Code/Library/WinAPI.cpp
+++ b/Code/Library/WinAPI.cpp
@@ -870,7 +870,6 @@ int WinAPI::HTTPRequest(
 	const std::string_view & url,
 	const std::string_view & data,
 	const std::map<std::string, std::string> & headers,
-	int timeout,
 	HTTPRequestCallback callback
 ){
 	std::wstring urlW;
@@ -895,11 +894,6 @@ int WinAPI::HTTPRequest(
 	if (!hSession)
 	{
 		throw StringTools::SysErrorFormat("WinHttpOpen");
-	}
-
-	if (!WinHttpSetTimeouts(hSession, timeout, timeout, timeout, timeout))
-	{
-		throw StringTools::SysErrorFormat("WinHttpSetTimeouts");
 	}
 
 	const std::wstring serverNameW(urlComponents.lpszHostName, urlComponents.dwHostNameLength);

--- a/Code/Library/WinAPI.h
+++ b/Code/Library/WinAPI.h
@@ -270,7 +270,6 @@ namespace WinAPI
 		const std::string_view & url,
 		const std::string_view & data,
 		const std::map<std::string, std::string> & headers,
-		int timeout,
 		HTTPRequestCallback callback
 	);
 


### PR DESCRIPTION
Fix mysterious HTTP download timeouts. We need to get rid of WinHTTP finally (#70).