### PR TITLE
Fix mouse cursor visibility and confinement

### DIFF
--- a/Code/CryGame/Game.cpp
+++ b/Code/CryGame/Game.cpp
@@ -109,8 +109,6 @@ CGame::CGame()
 	m_pDefaultAM = 0;
 	m_pMultiplayerAM = 0;
 
-	m_isMousePointerVisible = true;
-
 	GetISystem()->SetIGame(this);
 }
 
@@ -632,8 +630,6 @@ void CGame::InitHUD(IActor* pActor)
 void CGame::DestroyHUD()
 {
 	SAFE_DELETE(m_pHUD);
-
-	g_pGame->ShowMousePointer(true); //CryMP making sure pointer is visible after disco..
 }
 
 void CGame::BlockingProcess(BlockingConditionFunction f)
@@ -682,61 +678,6 @@ CFlashMenuObject* CGame::GetMenu() const
 COptionsManager* CGame::GetOptions() const
 {
 	return m_pOptionsManager;
-}
-
-bool CGame::IsMenuActive() const
-{
-	return GetMenu() && GetMenu()->IsActive();
-}
-
-bool CGame::ShowMousePointer(bool show)
-{
-	if (show == m_isMousePointerVisible)
-	{
-		return false;
-	}
-
-	if (m_isMousePointerVisible)
-	{
-		// hide mouse cursor
-
-		if (gEnv->pHardwareMouse)
-		{
-			gEnv->pHardwareMouse->DecrementCounter();
-		}
-
-		m_isMousePointerVisible = false;
-	}
-	else
-	{
-		// show mouse cursor
-
-		if (gEnv->pHardwareMouse)
-		{
-			gEnv->pHardwareMouse->IncrementCounter();
-		}
-
-		m_isMousePointerVisible = true;
-	}
-
-	return true;
-}
-
-void CGame::ConfineCursor(bool confine)
-{
-	if (gEnv->pHardwareMouse)
-	{
-		int fullscreen = 0;
-		if (ICVar* pFullscreenCVar = gEnv->pConsole->GetCVar("r_Fullscreen"))
-		{
-			fullscreen = pFullscreenCVar->GetIVal();
-		}
-
-		if (!fullscreen)
-		{
-			gEnv->pHardwareMouse->ConfineCursor(confine);
-		}
-	}
 }
 
 void CGame::LoadActionMaps(const char* filename)

--- a/Code/CryGame/Game.h
+++ b/Code/CryGame/Game.h
@@ -188,16 +188,6 @@ public:
 
   ILINE SCVars *GetCVars() {return m_pCVars;}
 
-
-    bool IsMenuActive() const;
-    bool ShowMousePointer(bool show);
-    void ConfineCursor(bool confine);
-
-	bool IsMousePointerVisible() const
-	{
-		return m_isMousePointerVisible;
-	}
-
 protected:
 	virtual void LoadActionMaps(const char* filename = "libs/config/defaultProfile.xml");
 
@@ -287,16 +277,9 @@ protected:
 
 	typedef std::map<string, string, stl::less__stricmp<string> > TLevelMapMap;
 	TLevelMapMap m_mapNames;
-
-private:
-	bool m_isMousePointerVisible;
 };
 
 extern CGame *g_pGame;
-
-#define SAFE_HARDWARE_MOUSE_FUNC(func)\
-	if(gEnv->pHardwareMouse)\
-		gEnv->pHardwareMouse->func
 
 #define SAFE_MENU_FUNC(func)\
 	{	if(g_pGame && g_pGame->GetMenu()) g_pGame->GetMenu()->func; }

--- a/Code/CryGame/HUD/HUD.cpp
+++ b/Code/CryGame/HUD/HUD.cpp
@@ -2090,7 +2090,7 @@ bool CHUD::OnAction(const ActionId& action, int activationMode, float value)
 
 	else if (action == rGameActions.xi_rotatepitch || action == rGameActions.xi_v_rotatepitch)
 	{
-		if (g_pGame->IsMousePointerVisible())
+		if (m_cursorVisibilityCounter > 0)
 		{
 			m_fAutosnapCursorControllerY = value * value * (-value);
 		}
@@ -2103,7 +2103,7 @@ bool CHUD::OnAction(const ActionId& action, int activationMode, float value)
 	}
 	else if (action == rGameActions.xi_rotateyaw || action == rGameActions.xi_v_rotateyaw)
 	{
-		if (g_pGame->IsMousePointerVisible())
+		if (m_cursorVisibilityCounter > 0)
 		{
 			m_fAutosnapCursorControllerX = value * value * value;
 		}
@@ -2859,7 +2859,7 @@ bool CHUD::ShowPDA(bool show, bool buyMenu)
 
 void CHUD::OnHardwareMouseEvent(int iX, int iY, EHARDWAREMOUSEEVENT eHardwareMouseEvent)
 {
-	if (!g_pGame->IsMousePointerVisible())
+	if (m_cursorVisibilityCounter <= 0)
 	{
 		return;
 	}

--- a/Code/CryGame/HUD/HUDCommon.cpp
+++ b/Code/CryGame/HUD/HUDCommon.cpp
@@ -118,12 +118,11 @@ CHUDCommon::CHUDCommon()
 
 CHUDCommon::~CHUDCommon()
 {
-	if (g_pGame->ShowMousePointer(false))
+	if (m_cursorVisibilityCounter > 0)
 	{
-		if (g_pGameActions && g_pGameActions->FilterNoMouse())
-		{
-			g_pGameActions->FilterNoMouse()->Enable(false);
-		}
+		m_cursorVisibilityCounter = 1;
+
+		this->CursorDecrementCounter();
 	}
 
 	if (gEnv->pHardwareMouse)
@@ -177,13 +176,19 @@ void CHUDCommon::SetGODMode(uint8 ucGodMode, bool forceUpdate)
 
 void CHUDCommon::CursorIncrementCounter()
 {
-	if (g_pGame->ShowMousePointer(true))
+	m_cursorVisibilityCounter++;
+
+	if (m_cursorVisibilityCounter == 1)
 	{
+		if (gEnv->pHardwareMouse)
+		{
+			gEnv->pHardwareMouse->IncrementCounter();
+		}
+
 		if (g_pGameActions && g_pGameActions->FilterNoMouse())
 		{
 			g_pGameActions->FilterNoMouse()->Enable(true);
 		}
-		//UpdateCrosshairVisibility();
 	}
 }
 
@@ -191,13 +196,25 @@ void CHUDCommon::CursorIncrementCounter()
 
 void CHUDCommon::CursorDecrementCounter()
 {
-	if (g_pGame->ShowMousePointer(false))
+	if (m_cursorVisibilityCounter <= 0)
 	{
+		CryLogError("%s: Too many decrements!", __FUNCTION__);
+		return;
+	}
+
+	m_cursorVisibilityCounter--;
+
+	if (m_cursorVisibilityCounter == 0)
+	{
+		if (gEnv->pHardwareMouse)
+		{
+			gEnv->pHardwareMouse->DecrementCounter();
+		}
+
 		if (g_pGameActions && g_pGameActions->FilterNoMouse())
 		{
 			g_pGameActions->FilterNoMouse()->Enable(false);
 		}
-		//UpdateCrosshairVisibility();
 	}
 }
 

--- a/Code/CryGame/HUD/HUDCommon.h
+++ b/Code/CryGame/HUD/HUDCommon.h
@@ -97,6 +97,8 @@ protected:
 	float					m_fLastGodModeUpdate;
 	char					m_strGODMode[32];
 
+	int m_cursorVisibilityCounter = 0;
+
 	// Cached sizes
 	int						m_width;
 	int						m_height;

--- a/Code/CryGame/Menus/FlashMenuObject.h
+++ b/Code/CryGame/Menus/FlashMenuObject.h
@@ -336,6 +336,7 @@ private:
 	ButtonPosMap::iterator FindButton(const char* shortcut);
 
 	bool ShouldIgnoreInGameEvent();
+	void ShowMouseCursor(bool show);
 
 	int m_iMaxProgress;
 
@@ -363,6 +364,7 @@ private:
 	bool m_bInLoading;
 	bool m_bLoadingDone;
 	bool m_bTutorialVideo;
+	bool m_isMouseCursorVisible = true;
 	int m_nBlackGraceFrames;
 	int m_nLastFrameUpdateID;
 	int m_iGamepadsConnected;

--- a/Code/CrySystem/HardwareMouse.cpp
+++ b/Code/CrySystem/HardwareMouse.cpp
@@ -94,6 +94,12 @@ void HardwareMouse::IncrementCounter()
 
 void HardwareMouse::DecrementCounter()
 {
+	if (m_counter <= 0)
+	{
+		CryLogErrorAlways("%s: Too many decrements!", __FUNCTION__);
+		return;
+	}
+
 	m_counter--;
 
 	if (m_counter == 0)
@@ -159,6 +165,7 @@ void HardwareMouse::Reset(bool visibleByDefault)
 	m_acceleration = 1;
 	m_hasFocus = true;
 	m_cursorReleased = false;
+	m_cursorConfineDisabled = false;
 
 	if (!visibleByDefault)
 	{
@@ -168,6 +175,13 @@ void HardwareMouse::Reset(bool visibleByDefault)
 
 void HardwareMouse::ConfineCursor(bool confine)
 {
+	m_cursorConfined = confine;
+
+	if (confine && m_cursorConfineDisabled)
+	{
+		return;
+	}
+
 	const bool isEditor = gEnv->pSystem->IsEditor();
 
 	void* window = isEditor ? gEnv->pRenderer->GetCurrentContextHWND() : gEnv->pRenderer->GetHWND();
@@ -295,6 +309,21 @@ bool HardwareMouse::OnInputEventUI(const SInputEvent& event)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+
+void HardwareMouse::DisableConfineCursor(bool disable)
+{
+	if (m_cursorConfineDisabled == disable)
+	{
+		return;
+	}
+
+	m_cursorConfineDisabled = disable;
+
+	if (m_cursorConfined)
+	{
+		this->ConfineCursor(!disable);
+	}
+}
 
 void HardwareMouse::ShowCursor(bool show)
 {

--- a/Code/CrySystem/HardwareMouse.h
+++ b/Code/CrySystem/HardwareMouse.h
@@ -16,6 +16,8 @@ class HardwareMouse : public IHardwareMouse, public ISystemEventListener, public
 	float m_acceleration = 1;
 	bool m_hasFocus = true;
 	bool m_cursorReleased = false;
+	bool m_cursorConfined = false;
+	bool m_cursorConfineDisabled = false;
 
 	std::vector<IHardwareMouseEventListener*> m_listeners;
 
@@ -75,6 +77,8 @@ public:
 	bool OnInputEventUI(const SInputEvent& event) override;
 
 	////////////////////////////////////////////////////////////////////////////////
+
+	void DisableConfineCursor(bool disable);
 
 private:
 	void ShowCursor(bool show);


### PR DESCRIPTION
- Close #177.
- Remove mouse-cursor-related stuff from `Game` class.
- Remove the `WM_PAINT` hack.
- Add handling of mismatched `WM_ENTERSIZEMOVE` and `WM_EXITSIZEMOVE`.
- Replace `EVENT_SYSTEM_MENUPOPUPSTART`/`EVENT_SYSTEM_MENUPOPUPEND` with `WM_ACTIVATE`/`WM_SETFOCUS`/`WM_KILLFOCUS`.
