### PR TITLE
Fix crash when spawning US_trolley

### DIFF
--- a/Code/CryAction/Vehicles/Implementations/Alien_warrior.cpp
+++ b/Code/CryAction/Vehicles/Implementations/Alien_warrior.cpp
@@ -1653,6 +1653,12 @@ bool Alien_warrior::Init(IGameObject* pGameObject)
 		this->InitActions(table);
 	}
 
+	// Damages
+	{
+		SmartScriptTable table(gEnv->pScriptSystem);
+		this->InitDamages(table);
+	}
+
 	this->InitMaxDamage();
 	this->AttachScriptBindToSeats();
 

--- a/Code/CryAction/Vehicles/Implementations/DefaultVehicle.cpp
+++ b/Code/CryAction/Vehicles/Implementations/DefaultVehicle.cpp
@@ -153,6 +153,12 @@ bool DefaultVehicle::Init(IGameObject* pGameObject)
 	// SeatTransitions
 	this->InitSeatTransitions();
 
+	// Damages
+	{
+		SmartScriptTable table(gEnv->pScriptSystem);
+		this->InitDamages(table);
+	}
+
 	this->InitMaxDamage();
 	this->AttachScriptBindToSeats();
 

--- a/Code/CryAction/Vehicles/Implementations/US_trolley.cpp
+++ b/Code/CryAction/Vehicles/Implementations/US_trolley.cpp
@@ -388,6 +388,12 @@ bool US_trolley::Init(IGameObject* pGameObject)
 		this->InitActions(table);
 	}
 
+	// Damages
+	{
+		SmartScriptTable table(gEnv->pScriptSystem);
+		this->InitDamages(table);
+	}
+
 	this->InitMaxDamage();
 	this->AttachScriptBindToSeats();
 

--- a/Tools/xml2cpp_vehicles.py
+++ b/Tools/xml2cpp_vehicles.py
@@ -521,9 +521,21 @@ class VehicleConverter:
 			self._process_actions(actions)
 			self._write('')
 
+		has_damages = False
 		for damages in self.xml_root.findall('./Damages'):
+			has_damages = True
 			self._write('// Damages')
 			self._process_damages(damages)
+			self._write('')
+
+		if not has_damages:
+			# emit empty damages to make sure Vehicle::InitDamages is always called
+			# we must call Vehicle::InitDamages always to avoid a null pointer crash in the original code
+			self._write('// Damages')
+			self._begin_block()
+			self._write('SmartScriptTable table(gEnv->pScriptSystem);')
+			self._write('this->InitDamages(table);')
+			self._end_block()
 			self._write('')
 
 		# TODO: dump animated parts when v_debugdraw cvar is set to 3


### PR DESCRIPTION
The original `Vehicle::InitDamages` must be called always during vehicle initialization.