### PR TITLE
Fix sky color & fog color in the weather system

### DIFF
--- a/Code/CryMP/Client/Advertising.cpp
+++ b/Code/CryMP/Client/Advertising.cpp
@@ -348,7 +348,7 @@ IMaterial* CAdManager::FindMaterial(const SAdGroup& group, const SAdVersion& ver
 	IMaterialManager* pMatMan(gEnv->p3DEngine->GetMaterialManager());
 	IMaterial* pNM(pMatMan->FindMaterial(name.c_str()));
 	if (!pNM) {
-		IMaterial* pMatSrc(pMatMan->LoadMaterial("Materials/Presets/MaterialTypes/clean/mat_metal_brushed", false, true));
+		IMaterial* pMatSrc(pMatMan->LoadMaterial("Materials/Presets/MaterialTypes/clean/mat_wood", false, true));
 		if (pMatSrc)
 		{
 			IMaterial* pMatDst(pMatMan->CreateMaterial(name.c_str(), pMatSrc->GetFlags() | MTL_FLAG_NON_REMOVABLE));
@@ -358,7 +358,7 @@ IMaterial* CAdManager::FindMaterial(const SAdGroup& group, const SAdVersion& ver
 
 				SInputShaderResources isr(si.m_pShaderResources);
 				isr.m_Textures[EFTT_DIFFUSE].m_Name = version.path.c_str();
-				isr.m_GlowAmount = 0.75f;
+				isr.m_GlowAmount = 0.4f;
 
 				SShaderItem siDst(gEnv->pRenderer->EF_LoadShaderItem(si.m_pShader->GetName(), true, EF_FORCE_RELOAD, &isr, si.m_pShader->GetGenerationMask()));
 				pMatDst->AssignShaderItem(siDst);
@@ -433,7 +433,7 @@ void CAdManager::FetchAds() {
 				  m_state = EAdState::eAS_Error;
 				}
 			} else {
-				 CryLogAlways("$4Failed to retrieve ads: %d", result.code);
+				 CryLogWarning("$4Failed to retrieve ads: %d", result.code);
 				 m_cycles[AD_CYCLE_ERROR] = m_time;
 				 m_state = EAdState::eAS_Error;
 			}

--- a/Code/CryMP/Client/WeatherSystem.cpp
+++ b/Code/CryMP/Client/WeatherSystem.cpp
@@ -541,15 +541,26 @@ void CWeatherSystem::TODUpdate(bool interpolate, bool force) {
 	// as otherwise setting these would be really cumbersome given that
 	// i.e. sky color is orange in morning, but blue during the day
 	if (interpolate) {
-		// sky color (TOD implementation basically just sets IEngine3D's sky color)
 		ITimeOfDay::SVariableInfo info;
 		float x, y, z;
-		auto it = self->m_activeValues.find(WEATHER_ENV_NAMESPACE + 6);
+
+		// 2103 = Sun color
+		auto it = self->m_activeValues.find(WEATHER_ENV_NAMESPACE + 3);
+		if (it != self->m_activeValues.end() && it->second.length() > 0 && it->second[0] == 'v' && sscanf(it->second.c_str() + 1, "%f,%f,%f", &x, &y, &z) == 3) {
+			gEnv->p3DEngine->SetSunColor(
+				gEnv->p3DEngine->GetSunColor().CompMul(Vec3(x, y, z))
+			);
+		}
+
+		// 2106 = Sky color
+		it = self->m_activeValues.find(WEATHER_ENV_NAMESPACE + 6);
 		if (it != self->m_activeValues.end() && it->second.length() > 0 && it->second[0] == 'v' && sscanf(it->second.c_str() + 1, "%f,%f,%f", &x, &y, &z) == 3) {
 			gEnv->p3DEngine->SetSkyColor(
 				gEnv->p3DEngine->GetSkyColor().CompMul(Vec3(x, y, z))
 			);
 		}
+
+		// 2108 = Fog color
 		it = self->m_activeValues.find(WEATHER_ENV_NAMESPACE + 8);
 		if (it != self->m_activeValues.end() && it->second.length() > 0 && it->second[0] == 'v' && sscanf(it->second.c_str() + 1, "%f,%f,%f", &x, &y, &z) == 3) {
 			gEnv->p3DEngine->SetFogColor(

--- a/Code/CryMP/Client/WeatherSystem.h
+++ b/Code/CryMP/Client/WeatherSystem.h
@@ -1,6 +1,12 @@
 #pragma once
-#include <utility>
+#include <array>
+#include <map>
 #include <optional>
+#include <set>
+#include <string>
+#include <utility>
+
+#include "CryCommon/CryMath/Cry_Math.h"
 
 struct WeatherVariable {
 	float value;
@@ -9,6 +15,43 @@ struct WeatherVariable {
 };
 
 class CWeatherSystem {
+	enum EWeatherVars {
+		WEATHER_ENABLED,
+		WEATHER_WIND,
+		WEATHER_FX,
+		WEATHER_LAYERS,
+		WEATHER_VAR_COUNT
+	};
+
+	struct SEffectInfo {
+		std::string effect;
+		float scale = 1.0f;
+		unsigned instances = 1;
+		Vec3 dir = Vec3(0.0f, 0.0f, 1.0f);
+		Vec3 pos = Vec3(512.0f, 512.0f, 64.0f);
+	};
+
+	bool                          m_enabled = false;
+	std::map<int, float[3]>       m_originalWeatherValues;
+	std::optional<Vec3>           m_originalWind;
+	std::map<int, IStatInstGroup> m_originalGroups;
+
+	std::map<int, string>                                 m_activeValues;
+	std::set<std::string>                                 m_activeEffects;
+	std::optional<unsigned>                               m_activeMask;
+	std::map<std::string, std::vector<IParticleEmitter*>> m_activeEmitters;
+
+	float m_time;
+	float m_lastUpdate;
+
+	static bool tod_hooked;
+	static constexpr int WEATHER_NAMESPACE = 2000;
+	static constexpr int WEATHER_ENV_NAMESPACE = 2100;
+
+	static constexpr std::array<EERType, 1> static_entities = {
+		eERType_Brush,
+	};
+
 public:
 	CWeatherSystem();
 	void Update(float frameTime);
@@ -33,6 +76,11 @@ private:
 	void ApplyLayer(unsigned layer);
 	void RemoveLayer(unsigned layer);
 
-	float m_time;
-	float m_lastUpdate;
+	// Hook functions
+	void TODUpdate(bool interpolate, bool force);
+
+	// Utility functions
+	std::string GetFrozenGrassName(std::string_view path);
+	std::string GetNormalGrassName(std::string_view path);
+	SEffectInfo GetEffectInfo(std::string_view effect);
 };


### PR DESCRIPTION
Sky color and fog color settings were not working in the weather system previously as they are a color spline.

The colors can now be configured as multiplier instead that are applied after TOD interpolations are done.

Here is before and after (notice the shadow colors especially)

![ScreenShot0108](https://github.com/user-attachments/assets/4116b169-0c7b-45ce-91e9-876b12eb3008)
![ScreenShot0107](https://github.com/user-attachments/assets/910a52f1-140b-414b-a8bb-14839f11c229)

![ScreenShot0105](https://github.com/user-attachments/assets/f0713f54-aa53-48e1-a7bd-72ab310ddc7f)
![ScreenShot0106](https://github.com/user-attachments/assets/ff902ad0-4f32-4ef7-8396-fcc0874f99b8)
