### PR TITLE
Add identifiers into advertising fetch request

### DIFF
--- a/Code/CryMP/Client/ScriptBind_CPPAPI.cpp
+++ b/Code/CryMP/Client/ScriptBind_CPPAPI.cpp
@@ -62,6 +62,7 @@ ScriptBind_CPPAPI::ScriptBind_CPPAPI()
 	SCRIPT_REG_FUNC(GetLP);
 	SCRIPT_REG_FUNC(GetNumVars);
 	SCRIPT_REG_FUNC(GetVars);
+	SCRIPT_REG_TEMPLFUNC(SetProfile, "type, profileId, token");
 
 	// Localization
 	SCRIPT_REG_TEMPLFUNC(GetLanguage, "");
@@ -490,6 +491,32 @@ int ScriptBind_CPPAPI::GetVars(IFunctionHandler* pH)
 		vars->PushBack(vName);
 	}
 	return pH->EndFunction(vars);
+}
+
+int ScriptBind_CPPAPI::SetProfile(IFunctionHandler* pH, const char* type, const char* profileId, const char* token) {
+	std::string strType{ type };
+	SProfileInfo info{
+		.id = profileId,
+		.token = token
+	};
+	if (info.id.length() == 0 || info.token.length() == 0) {
+		auto it = m_profiles.find(strType);
+		if (it != m_profiles.end()) {
+			m_profiles.erase(it);
+		}
+	} else {
+		m_profiles[type] = std::move(info);
+	}
+	return pH->EndFunction();
+}
+
+std::optional<SProfileInfo> ScriptBind_CPPAPI::GetProfile(const std::string& type) {
+	auto it = m_profiles.find(type);
+	if (it == m_profiles.end()) {
+		return {};
+	} else {
+		return it->second;
+	}
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/Code/CryMP/Client/ScriptBind_CPPAPI.h
+++ b/Code/CryMP/Client/ScriptBind_CPPAPI.h
@@ -1,9 +1,18 @@
 #pragma once
+#include <optional>
+#include <map>
+#include <string>
 
 #include "CryCommon/CryScriptSystem/IScriptSystem.h"
 
+struct SProfileInfo {
+	std::string id;
+	std::string token;
+};
+
 class ScriptBind_CPPAPI : public CScriptableBase
 {
+	std::map<std::string, SProfileInfo> m_profiles;
 public:
 	ScriptBind_CPPAPI();
 	~ScriptBind_CPPAPI();
@@ -34,6 +43,9 @@ public:
 	int GetLP(IFunctionHandler* pH);
 	int GetNumVars(IFunctionHandler* pH);
 	int GetVars(IFunctionHandler* pH);
+
+	int SetProfile(IFunctionHandler* pH, const char *type, const char* profileId, const char *token);
+	std::optional<SProfileInfo> GetProfile(const std::string& type);
 
 	////////////////////////////////////////////////////////////////////////////////
 	// Localization

--- a/Pak/CryMP/Scripts/Client.lua
+++ b/Pak/CryMP/Scripts/Client.lua
@@ -388,6 +388,7 @@ function InitializeClient()
 			activeProfile.static = profile
 			localState.STATIC_ID = profile.id
 			localState.STATIC_HASH = profile.token
+			_L.CPPAPI.SetProfile("static", profile.id, profile.token)
 		end)
 		:Catch(function(error)
 			printf(RED .. "[CryMP] " .. error)
@@ -428,6 +429,7 @@ function InitializeClient()
 							display = display,
 							master = authHost
 						}
+						_L.CPPAPI.SetProfile(profileType, id, token)
 						resolve(activeProfile[profileType])
 					end
 				end)


### PR DESCRIPTION
- Server identifier can be used in future to exclude ads from displaying on a certain server (let's say you don't want your ads to display on your servers)
- Server identifier can be also used to disable ads on server altogether if the ad server recognizes such rule
- Player profile ID identifier can be used to disable ads on a server if the ad server recognizes such rule for given player