### PR TITLE
Fix Asian_ltv modifications

### DIFF
--- a/Code/CryAction/Vehicles/Implementations/Asian_ltv.cpp
+++ b/Code/CryAction/Vehicles/Implementations/Asian_ltv.cpp
@@ -176,7 +176,7 @@ bool Asian_ltv::Init(IGameObject* pGameObject)
 				}
 				else if (StringTools::IsEqualNoCase(m_modName, "Unarmed"))
 				{
-					roof_part_1_part->SetValue("useOption", 0);
+					roof_part_1_part->SetValue("useOption", 1);
 				}
 				else if (StringTools::IsEqualNoCase(m_modName, "Gauss"))
 				{
@@ -211,7 +211,7 @@ bool Asian_ltv::Init(IGameObject* pGameObject)
 				}
 				else if (StringTools::IsEqualNoCase(m_modName, "Unarmed"))
 				{
-					roof_part_2_part->SetValue("useOption", 0);
+					roof_part_2_part->SetValue("useOption", 1);
 				}
 				else if (StringTools::IsEqualNoCase(m_modName, "Gauss"))
 				{
@@ -246,7 +246,7 @@ bool Asian_ltv::Init(IGameObject* pGameObject)
 				}
 				else if (StringTools::IsEqualNoCase(m_modName, "Unarmed"))
 				{
-					roof_part_3_part->SetValue("useOption", 0);
+					roof_part_3_part->SetValue("useOption", 1);
 				}
 				else if (StringTools::IsEqualNoCase(m_modName, "Gauss"))
 				{
@@ -281,7 +281,7 @@ bool Asian_ltv::Init(IGameObject* pGameObject)
 				}
 				else if (StringTools::IsEqualNoCase(m_modName, "Unarmed"))
 				{
-					roof_part_4_part->SetValue("useOption", 0);
+					roof_part_4_part->SetValue("useOption", 1);
 				}
 				else if (StringTools::IsEqualNoCase(m_modName, "Gauss"))
 				{
@@ -2466,7 +2466,7 @@ bool Asian_ltv::Init(IGameObject* pGameObject)
 		}
 		else if (StringTools::IsEqualNoCase(m_modName, "Unarmed"))
 		{
-			seat_sounds->SetValue("mood", 0.6f);
+			seat_sounds->SetValue("mood", 0.0f);
 		}
 		else if (StringTools::IsEqualNoCase(m_modName, "Gauss"))
 		{
@@ -2635,7 +2635,7 @@ bool Asian_ltv::Init(IGameObject* pGameObject)
 		}
 		else if (StringTools::IsEqualNoCase(m_modName, "Unarmed"))
 		{
-			seat_sounds->SetValue("mood", 0.6f);
+			seat_sounds->SetValue("mood", 0.0f);
 		}
 		else if (StringTools::IsEqualNoCase(m_modName, "Gauss"))
 		{
@@ -2707,7 +2707,7 @@ bool Asian_ltv::Init(IGameObject* pGameObject)
 		}
 		else if (StringTools::IsEqualNoCase(m_modName, "Unarmed"))
 		{
-			seat_sounds->SetValue("mood", 0.6f);
+			seat_sounds->SetValue("mood", 0.0f);
 		}
 		else if (StringTools::IsEqualNoCase(m_modName, "Gauss"))
 		{
@@ -2779,7 +2779,7 @@ bool Asian_ltv::Init(IGameObject* pGameObject)
 		}
 		else if (StringTools::IsEqualNoCase(m_modName, "Unarmed"))
 		{
-			seat_sounds->SetValue("mood", 0.6f);
+			seat_sounds->SetValue("mood", 0.0f);
 		}
 		else if (StringTools::IsEqualNoCase(m_modName, "Gauss"))
 		{

--- a/Tools/xml2cpp_vehicles.py
+++ b/Tools/xml2cpp_vehicles.py
@@ -675,23 +675,28 @@ class VehicleConverter:
 
 	def _load_mods(self, mods: ET.Element):
 		for mod in mods:
-			assert mod.tag == 'Modification'
 			mod_name = mod.attrib['name']
 			if 'parent' in mod.attrib:
 				parent_name = mod.attrib['parent']
-				mod.extend(mods.findall(f'./Modification[@name="{parent_name}"]/Elems'))
-			for elems in mod:
-				assert elems.tag == 'Elems'
-				for elem in elems:
-					assert elem.tag == 'Elem'
-					elem_ref = elem.attrib['idRef']
-					elem_name = elem.attrib['name']
-					elem_value = elem.attrib['value']
-					if elem_ref not in self.mods:
-						self.mods[elem_ref] = {}
-					if elem_name not in self.mods[elem_ref]:
-						self.mods[elem_ref][elem_name] = {}
-					self.mods[elem_ref][elem_name][mod_name] = elem_value
+				for parent in mods.findall(f'./Modification[@name="{parent_name}"]'):
+					assert 'parent' not in parent.attrib
+					self._add_mod(parent, mod_name)
+			self._add_mod(mod, mod_name)
+
+	def _add_mod(self, mod: ET.Element, mod_name: str):
+		assert mod.tag == 'Modification'
+		for elems in mod:
+			assert elems.tag == 'Elems'
+			for elem in elems:
+				assert elem.tag == 'Elem'
+				elem_ref = elem.attrib['idRef']
+				elem_name = elem.attrib['name']
+				elem_value = elem.attrib['value']
+				if elem_ref not in self.mods:
+					self.mods[elem_ref] = {}
+				if elem_name not in self.mods[elem_ref]:
+					self.mods[elem_ref][elem_name] = {}
+				self.mods[elem_ref][elem_name][mod_name] = elem_value
 
 	################################################################################
 	# Physics


### PR DESCRIPTION
Fix a subtle bug in `xml2cpp_vehicles.py` causing parent vehicle modifications to overwrite values of their child modifications. Now it's the other way around as it should be. Surprisingly, only Asian_ltv was affected.

Close #261