### PR TITLE
Fix new ToD and enable it by default

### DIFF
--- a/Code/Cry3DEngine/TimeOfDay.cpp
+++ b/Code/Cry3DEngine/TimeOfDay.cpp
@@ -486,9 +486,14 @@ void TimeOfDay::Update(bool interpolate, bool forceUpdate)
 		m_vars[NIGHT_SKY_MOON_OUTER_CORONA_SCALE].value[0]
 	);
 
-	p3DEngine->SetPostEffectParam("SunShafts_Active", m_vars[SUN_SHAFTS_VISIBILITY].value[0] > 0.05 ? 1 : 0);
-	p3DEngine->SetPostEffectParam("SunShafts_Amount", m_vars[SUN_SHAFTS_VISIBILITY].value[0]);
-	p3DEngine->SetPostEffectParam("SunShafts_RaysAmount", m_vars[SUN_RAYS_VISIBILITY].value[0]);
+	float sunShaftsVis = m_vars[SUN_SHAFTS_VISIBILITY].value[0];
+	sunShaftsVis = std::clamp<float>(sunShaftsVis, 0.0f, 0.3f);
+	float sunRaysVis = m_vars[SUN_RAYS_VISIBILITY].value[0];
+
+	p3DEngine->SetPostEffectParam("SunShafts_Active",
+		(sunShaftsVis > 0.05 || sunRaysVis > 0.05) ? 1 : 0);
+	p3DEngine->SetPostEffectParam("SunShafts_Amount", sunShaftsVis);
+	p3DEngine->SetPostEffectParam("SunShafts_RaysAmount", sunRaysVis);
 	p3DEngine->SetPostEffectParam("SunShafts_RaysAttenuation", m_vars[SUN_RAYS_ATTENUATION].value[0]);
 
 	p3DEngine->SetCloudShadingMultiplier(

--- a/Code/CryCommon/Cry3DEngine/I3DEngine.h
+++ b/Code/CryCommon/Cry3DEngine/I3DEngine.h
@@ -2157,22 +2157,38 @@ struct I3DEngine : public IProcess
 
 	float GetDawnStart()
 	{
+#ifdef BUILD_64BIT
 		return *(reinterpret_cast<float*>(this) + 91);
+#else
+		return *(reinterpret_cast<float*>(this) + 88);
+#endif
 	}
 
 	float GetDawnEnd()
 	{
+#ifdef BUILD_64BIT
 		return *(reinterpret_cast<float*>(this) + 92);
+#else
+		return *(reinterpret_cast<float*>(this) + 89);
+#endif
 	}
 
 	float GetDuskStart()
 	{
+#ifdef BUILD_64BIT
 		return *(reinterpret_cast<float*>(this) + 93);
+#else
+		return *(reinterpret_cast<float*>(this) + 90);
+#endif
 	}
 
 	float GetDuskEnd()
 	{
+#ifdef BUILD_64BIT
 		return *(reinterpret_cast<float*>(this) + 94);
+#else
+		return *(reinterpret_cast<float*>(this) + 91);
+#endif
 	}
 
 	////////////////////////////////////////////////////////////////////////////////

--- a/Code/Launcher/Launcher.cpp
+++ b/Code/Launcher/Launcher.cpp
@@ -578,8 +578,9 @@ static void ReplaceTimeOfDay(void* pCry3DEngine)
 
 	unsigned char dtorCode[] = {
 		0x48, 0xB8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // mov rax, 0x0
+		0x48, 0x8B, 0xCB,                                            // mov rcx, rbx
 		0xFF, 0xD0,                                                  // call rax
-		0x90, 0x90, 0x90, 0x90                                       // nop...
+		0x90                                                         // nop
 	};
 
 	unsigned char getHDRMultiplierCode[] = {

--- a/Code/Launcher/Launcher.cpp
+++ b/Code/Launcher/Launcher.cpp
@@ -591,13 +591,25 @@ static void ReplaceTimeOfDay(void* pCry3DEngine)
 		0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90         // nop...
 	};
 
+	unsigned char getHDRMultiplierCode2[] = {
+		0x48, 0xB8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // mov rax, 0x0
+		0xFF, 0xD0,                                                  // call rax
+		0x0F, 0x29, 0xB4, 0x24, 0x80, 0x00, 0x00, 0x00,              // movaps xmmword ptr ss:[rsp+0x80], xmm6
+		0x0F, 0x28, 0xF0,                                            // movaps xmm6, xmm0
+		0x33, 0xF6,                                                  // xor esi, esi
+		0x41, 0x39, 0xB4, 0x24, 0x80, 0x00, 0x00, 0x00,              // cmp dword ptr ds:[r12+0x80], esi
+		0x90, 0x90, 0x90, 0x90, 0x90, 0x90                           // nop...
+	};
+
 	std::memcpy(&ctorCode[2], &ctorFunc, 8);
 	std::memcpy(&dtorCode[2], &dtorFunc, 8);
 	std::memcpy(&getHDRMultiplierCode[2], &getHDRMultiplierFunc, 8);
+	std::memcpy(&getHDRMultiplierCode2[2], &getHDRMultiplierFunc, 8);
 
 	WinAPI::FillMem(WinAPI::RVA(pCry3DEngine, 0xFB81A), ctorCode, sizeof(ctorCode));
 	WinAPI::FillMem(WinAPI::RVA(pCry3DEngine, 0xFC505), dtorCode, sizeof(dtorCode));
 	WinAPI::FillMem(WinAPI::RVA(pCry3DEngine, 0xF38CC), getHDRMultiplierCode, sizeof(getHDRMultiplierCode));
+	WinAPI::FillMem(WinAPI::RVA(pCry3DEngine, 0x11E2C1), getHDRMultiplierCode2, sizeof(getHDRMultiplierCode2));
 #else
 	unsigned char ctorCode[] = {
 		0xB8, 0x00, 0x00, 0x00, 0x00,  // mov eax, 0x0
@@ -625,13 +637,25 @@ static void ReplaceTimeOfDay(void* pCry3DEngine)
 		0x90, 0x90, 0x90, 0x90               // nop...
 	};
 
+	unsigned char getHDRMultiplierCode2[] = {
+		0x55,                                // push ebp
+		0x89, 0x5C, 0x24, 0x0C,              // mov dword ptr ss:[esp+0xC], ebx
+		0xB8, 0x00, 0x00, 0x00, 0x00,        // mov eax, 0x0
+		0xFF, 0xD0,                          // call eax
+		0xD9, 0x5C, 0x24, 0xFC,              // fstp dword ptr ss:[esp-0x4], st(0)
+		0xF3, 0x0F, 0x10, 0x44, 0x24, 0xFC,  // movss xmm0, dword ptr ss:[esp-0x4]
+		0x90, 0x90, 0x90, 0x90               // nop...
+	};
+
 	std::memcpy(&ctorCode[1], &ctorFunc, 4);
 	std::memcpy(&dtorCode[1], &dtorFunc, 4);
 	std::memcpy(&getHDRMultiplierCode[1], &getHDRMultiplierFunc, 4);
+	std::memcpy(&getHDRMultiplierCode2[6], &getHDRMultiplierFunc, 4);
 
 	WinAPI::FillMem(WinAPI::RVA(pCry3DEngine, 0xBE70B), ctorCode, sizeof(ctorCode));
 	WinAPI::FillMem(WinAPI::RVA(pCry3DEngine, 0xBF0D6), dtorCode, sizeof(dtorCode));
 	WinAPI::FillMem(WinAPI::RVA(pCry3DEngine, 0xB8D7D), getHDRMultiplierCode, sizeof(getHDRMultiplierCode));
+	WinAPI::FillMem(WinAPI::RVA(pCry3DEngine, 0xDC5B6), getHDRMultiplierCode2, sizeof(getHDRMultiplierCode2));
 #endif
 }
 

--- a/Code/Launcher/Launcher.cpp
+++ b/Code/Launcher/Launcher.cpp
@@ -998,7 +998,7 @@ void Launcher::PatchEngine()
 	{
 		MemoryPatch::Cry3DEngine::FixGetObjectsByType(m_dlls.pCry3DEngine);
 
-		if (WinAPI::CmdLine::HasArg("-newtod"))
+		if (!WinAPI::CmdLine::HasArg("-oldtod"))
 		{
 			ReplaceTimeOfDay(m_dlls.pCry3DEngine);
 		}


### PR DESCRIPTION
- Fix #81 by hooking one forgotten `TimeOfDay::GetHDRMultiplier` call (non-virtual inline function).
- Fix various new ToD issues in 32-bit caused by the following functions not working correctly in 32-bit:
  - `I3DEngine::GetDawnStart`
  - `I3DEngine::GetDawnEnd`
  - `I3DEngine::GetDuskStart`
  - `I3DEngine::GetDuskEnd`
- Fix subtle differences in sun shafts compared to the original ToD implementation.
- Enable new ToD by default (`-newtod` is now `-oldtod`).

Big thanks to @griseraner for nailing down the issues!
