### PR TITLE
Fix game hang on first connect

### DIFF
--- a/Code/CryMP/Client/Client.cpp
+++ b/Code/CryMP/Client/Client.cpp
@@ -111,14 +111,30 @@ void Client::OnConnectCmd(IConsoleCmdArgs *pArgs)
 	const char *port = "";
 
 	if (pArgs->GetArgCount() > 1)
+	{
 		host = pArgs->GetArg(1);
+	}
 	else
-		host = pConsole->GetCVar("cl_serveraddr")->GetString();
+	{
+		ICVar* pClServerAddr = pConsole->GetCVar("cl_serveraddr");
+		if (pClServerAddr)
+		{
+			host = pClServerAddr->GetString();
+		}
+	}
 
 	if (pArgs->GetArgCount() > 2)
+	{
 		port = pArgs->GetArg(2);
+	}
 	else
-		port = pConsole->GetCVar("cl_serverport")->GetString();
+	{
+		ICVar* pClServerPort = pConsole->GetCVar("cl_serverport");
+		if (pClServerPort)
+		{
+			port = pClServerPort->GetString();
+		}
+	}
 
 	ServerInfo server;
 	server.master = gClient->m_masters[0];
@@ -228,6 +244,27 @@ void Client::Init(IGameFramework *pGameFramework)
 	pConsole->AddCommand("disconnect", OnDisconnectCmd, VF_RESTRICTEDMODE, "Usage: disconnect");
 	pConsole->AddCommand("bind", OnKeyBindCmd, VF_NOT_NET_SYNCED, "Usage: bind key command");
 	pConsole->AddCommand("dumpbinds", OnDumpKeyBindsCmd, VF_RESTRICTEDMODE, "Usage: dumpbinds");
+
+	ICVar* pSvPassword = pConsole->GetCVar("sv_password");
+	if (pSvPassword)
+	{
+		// disable adding password flag to GameSpy server report
+		pSvPassword->SetOnChangeCallback(nullptr);
+	}
+
+	ICVar* pSvGsReport = pConsole->GetCVar("sv_gs_report");
+	if (pSvGsReport)
+	{
+		// disable GameSpy server report
+		pSvGsReport->Set(0);
+	}
+
+	ICVar* pSvGsTrackStats = pConsole->GetCVar("sv_gs_trackstats");
+	if (pSvGsTrackStats)
+	{
+		// disable collecting game statistics for GameSpy
+		pSvGsTrackStats->Set(0);
+	}
 
 	if (!WinAPI::CmdLine::HasArg("-keepcdkey"))
 	{

--- a/Code/Launcher/Launcher.cpp
+++ b/Code/Launcher/Launcher.cpp
@@ -7,6 +7,7 @@
 #include "Cry3DEngine/TimeOfDay.h"
 #include "CryAction/GameFramework.h"
 #include "CryCommon/CryAction/IGameFramework.h"
+#include "CryCommon/CryNetwork/INetworkService.h"
 #include "CryCommon/CrySystem/FrameProfiler.h"
 #include "CryCommon/CrySystem/gEnv.h"
 #include "CryCommon/CrySystem/IConsole.h"
@@ -659,6 +660,37 @@ static void ReplaceTimeOfDay(void* pCry3DEngine)
 #endif
 }
 
+struct DummyCNetwork
+{
+	static inline INetworkServicePtr (DummyCNetwork::*s_pOriginalGetService)(const char* name);
+
+	INetworkServicePtr GetService(const char* name)
+	{
+		// log every access to the GameSpy service
+		// we want to eventually get rid of GameSpy completely
+		CryLogWarningAlways("INetwork::GetService(\"%s\")", name);
+
+		return (this->*s_pOriginalGetService)(name);
+	}
+};
+
+static void HookNetworkGetService(void* pCryNetwork)
+{
+	void** pCNetworkVTable = static_cast<void**>(WinAPI::RVA(pCryNetwork,
+#ifdef BUILD_64BIT
+		0x19BEE8
+#else
+		0xC0C90
+#endif
+	));
+
+	std::memcpy(&DummyCNetwork::s_pOriginalGetService, &pCNetworkVTable[7], sizeof(void*));
+
+	// vtable hook
+	auto pNewGetService = &DummyCNetwork::GetService;
+	WinAPI::FillMem(&pCNetworkVTable[7], &reinterpret_cast<void*&>(pNewGetService), sizeof(void*));
+}
+
 static void EnableHiddenProfilerSubsystems(ISystem* pSystem)
 {
 	struct Subsystem
@@ -966,6 +998,8 @@ void Launcher::PatchEngine()
 		MemoryPatch::CryNetwork::FixFileCheckCrash(m_dlls.pCryNetwork);
 		MemoryPatch::CryNetwork::FixInternetConnect(m_dlls.pCryNetwork);
 		MemoryPatch::CryNetwork::FixLanServerBrowser(m_dlls.pCryNetwork);
+
+		HookNetworkGetService(m_dlls.pCryNetwork);
 	}
 
 	if (m_dlls.pCrySystem)

--- a/Code/Launcher/Launcher.cpp
+++ b/Code/Launcher/Launcher.cpp
@@ -998,6 +998,7 @@ void Launcher::PatchEngine()
 		MemoryPatch::CryNetwork::FixFileCheckCrash(m_dlls.pCryNetwork);
 		MemoryPatch::CryNetwork::FixInternetConnect(m_dlls.pCryNetwork);
 		MemoryPatch::CryNetwork::FixLanServerBrowser(m_dlls.pCryNetwork);
+		MemoryPatch::CryNetwork::RemoveGameSpyAvailableCheck(m_dlls.pCryNetwork);
 
 		HookNetworkGetService(m_dlls.pCryNetwork);
 	}

--- a/Code/Launcher/MemoryPatch.cpp
+++ b/Code/Launcher/MemoryPatch.cpp
@@ -254,6 +254,46 @@ void MemoryPatch::CryNetwork::FixLanServerBrowser(void* pCryNetwork)
 #endif
 }
 
+/**
+ * Removes pointless GameSpy master server availability check.
+ */
+void MemoryPatch::CryNetwork::RemoveGameSpyAvailableCheck(void* pCryNetwork)
+{
+#ifdef BUILD_64BIT
+	char* gameName = static_cast<char*>(pCryNetwork) + 0x1FCE50;
+	int* gsAvailable = static_cast<int*>(pCryNetwork) + (0x1FCE48 / sizeof(int));
+#else
+	char* gameName = static_cast<char*>(pCryNetwork) + 0xF17C0;
+	int* gsAvailable = static_cast<int*>(pCryNetwork) + (0xF17BC / sizeof(int));
+#endif
+
+	std::strcpy(gameName, "crysis");
+	*gsAvailable = 1;
+
+#ifdef BUILD_64BIT
+	const unsigned char code[] = {
+		0xC7, 0x43, 0x28, 0x01, 0x00, 0x00, 0x00,  // mov dword ptr ds:[rbx+0x28], 0x1
+		0xC7, 0x43, 0x2C, 0x00, 0x00, 0x00, 0x00,  // mov dword ptr ds:[rbx+0x2C], 0x0
+	};
+#else
+	const unsigned char code[] = {
+		0x83, 0xC4, 0x0C,                          // add esp, 0xC
+		0xC7, 0x47, 0x14, 0x01, 0x00, 0x00, 0x00,  // mov dword ptr ds:[edi+0x14], 0x1
+		0xC7, 0x47, 0x18, 0x00, 0x00, 0x00, 0x00,  // mov dword ptr ds:[edi+0x18], 0x0
+	};
+#endif
+
+#ifdef BUILD_64BIT
+	FillNop(pCryNetwork, 0xF3C5E, 0x5);
+	FillNop(pCryNetwork, 0xF3C8E, 0x8B);
+	FillMem(pCryNetwork, 0xF3C8E, &code, sizeof(code));
+#else
+	FillNop(pCryNetwork, 0x586EC, 0x5);
+	FillNop(pCryNetwork, 0x5871A, 0x96);
+	FillMem(pCryNetwork, 0x5871A, &code, sizeof(code));
+#endif
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // CryRenderD3D9
 ////////////////////////////////////////////////////////////////////////////////

--- a/Code/Launcher/MemoryPatch.h
+++ b/Code/Launcher/MemoryPatch.h
@@ -32,6 +32,7 @@ namespace MemoryPatch
 		void FixFileCheckCrash(void* pCryNetwork);
 		void FixInternetConnect(void* pCryNetwork);
 		void FixLanServerBrowser(void* pCryNetwork);
+		void RemoveGameSpyAvailableCheck(void* pCryNetwork);
 	}
 
 	namespace CryRenderD3D9


### PR DESCRIPTION
- Fix #283 by removing GameSpy availability check.
- Further reduce GameSpy service usage on client:
    - Remove `sv_password` change callback that sets password flag in GameSpy server report.
    - Change the default value of `sv_gs_report` and `sv_gs_trackstats` to zero.
- Add `INetwork::GetService` hook to log every access to GameSpy service.
- Refactor `Client::OnConnectCmd` a bit.