### PR TITLE
fix: Module not found issue

### DIFF
--- a/Code/CrySystem/Pak/FileOutsidePak.cpp
+++ b/Code/CrySystem/Pak/FileOutsidePak.cpp
@@ -1,10 +1,7 @@
-#include <chrono>
-
 #include "CrySystem/CryLog.h"
+#include "Library/WinAPI.h"
 
 #include "FileOutsidePak.h"
-
-#include <windows.h>
 
 #if defined(_MSC_VER) || defined(__MINGW64__)
 #define FSEEK64 _fseeki64
@@ -111,22 +108,7 @@ void* FileOutsidePak::GetCachedFileData(std::size_t& fileSize)
 
 std::uint64_t FileOutsidePak::GetModificationTime()
 {
-    WIN32_FILE_ATTRIBUTE_DATA fileInfo;
-
-    if (GetFileAttributesExW(m_path.c_str(), GetFileExInfoStandard, &fileInfo))
-    {
-        ULARGE_INTEGER ull;
-        ull.LowPart = fileInfo.ftLastWriteTime.dwLowDateTime;
-        ull.HighPart = fileInfo.ftLastWriteTime.dwHighDateTime;
-
-        ull.QuadPart -= 116444736000000000ULL;
-
-        return ull.QuadPart / 10000000ULL;
-    }
-    else
-    {
-        return 0;
-    }
+	return WinAPI::GetLastWriteTime(m_path);
 }
 
 std::FILE* FileOutsidePak::GetHandle()

--- a/Code/Library/WinAPI.cpp
+++ b/Code/Library/WinAPI.cpp
@@ -129,6 +129,22 @@ void WinAPI::SetWorkingDirectory(const std::filesystem::path& path)
 	}
 }
 
+uint64_t WinAPI::GetLastWriteTime(const std::filesystem::path& path)
+{
+	WIN32_FILE_ATTRIBUTE_DATA attributes;
+	if (!GetFileAttributesExW(path.c_str(), GetFileExInfoStandard, &attributes))
+	{
+		return 0;
+	}
+
+	// https://learn.microsoft.com/en-us/windows/win32/sysinfo/converting-a-time-t-value-to-a-file-time
+	ULARGE_INTEGER time_value;
+	time_value.LowPart = attributes.ftLastWriteTime.dwLowDateTime;
+	time_value.HighPart = attributes.ftLastWriteTime.dwHighDateTime;
+	time_value.QuadPart -= 116444736000000000ULL;
+	return time_value.QuadPart / 10000000ULL;
+}
+
 /////////////
 // Modules //
 /////////////

--- a/Code/Library/WinAPI.h
+++ b/Code/Library/WinAPI.h
@@ -56,6 +56,8 @@ namespace WinAPI
 
 	void SetWorkingDirectory(const std::filesystem::path& path);
 
+	uint64_t GetLastWriteTime(const std::filesystem::path& path);
+
 	/////////////
 	// Modules //
 	/////////////


### PR DESCRIPTION
Replace `std::chrono::clock_cast` because it throws `std::runtime_error` on old Windows.