### PR TITLE
DrawTools: Add support for transparent images

### DIFF
--- a/Code/CryMP/Client/DrawTools.cpp
+++ b/Code/CryMP/Client/DrawTools.cpp
@@ -28,9 +28,22 @@ void DrawTools::OnUpdate()
 			gEnv->pRenderer->Draw2dImage(image.posX, image.posY, image.width, image.height, 0, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 
 				image.color[0], image.color[1], image.color[2], alpha);
 		}
-		else
+		else // Images
 		{
-			gEnv->pRenderer->Draw2dImage(image.posX, image.posY, image.width, image.height, image.textureId, 0.0f, 1.0f, 1.0f, 0.0f);
+			// Old:
+			//gEnv->pRenderer->Draw2dImage(image.posX, image.posY, image.width, image.height, image.textureId, 0.0f, 1.0f, 1.0f, 0.0f); 
+			
+			const float alpha = image.color[3];
+			gEnv->pRenderer->SetState(GS_BLSRC_SRCALPHA | GS_BLDST_ONEMINUSSRCALPHA | GS_NODEPTHTEST);// pdn:BC3 / DXT5
+			gEnv->pRenderer->Draw2dImage(
+				image.posX, image.posY,
+				image.width, image.height,
+				image.textureId,
+				//0.0f, 0.0f, 1.0f, 1.0f,  //  UVs
+				0.0f, 1.0f, 1.0f, 0.0f,
+				0.0f,                    // angle
+				1.0f, 1.0f, 1.0f, alpha //1.0f   // r,g,b,a
+			);
 		}
 	}
 


### PR DESCRIPTION
Added Support transparent pixels inside images to be rendered properly instead of as black squares

New: 
<img width="261" height="185" alt="e2" src="https://github.com/user-attachments/assets/0c97b521-d4e9-4b6d-bb7d-7bf84dfbeefc" />
Old: 
<img width="338" height="214" alt="e1" src="https://github.com/user-attachments/assets/02133cf6-6593-4c7d-87b7-4a2655243bfc" />
