### PR TITLE
FileCache: Fix empty index crash

### DIFF
--- a/Code/CryMP/Client/FileCache.cpp
+++ b/Code/CryMP/Client/FileCache.cpp
@@ -18,6 +18,11 @@ json FileCache::LoadIndex()
 		index = json::parse(file.GetHandle(), nullptr, false);  // no exceptions
 	}
 
+	if (!index.is_object())
+	{
+		index = json::object();
+	}
+
 	if (!index.contains("files") || !index["files"].is_object())
 	{
 		index["files"] = json::object();


### PR DESCRIPTION
When `Documents/My Games/Crysis/Downloads/Cache/index` file is empty, `FileCache::LoadIndex` throws the following exception, which is not handled anywhere, and client crashes.

```
[json.exception.type_error.305] cannot use operator[] with a string argument with discarded
```

Thanks to Checki for revealing this error!