### PR TITLE
New code signing certificate (2025)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Sign
         if: github.repository_owner == 'crymp-net'
         run: |
-          Get-ChildItem | Where-Object { $_.Extension -eq '.exe' } | ForEach-Object {
+          Get-ChildItem -Path '${{ env.BUILD_DIR }}' | Where-Object { $_.Extension -eq '.exe' } | ForEach-Object {
             $checksum = (Get-FileHash -Path $_.FullName -Algorithm SHA256).Hash.ToLower()
             $timestamp = [DateTimeOffset]::Now.ToUnixTimeSeconds()
             $hmac = New-Object System.Security.Cryptography.HMACSHA256
@@ -64,8 +64,9 @@ jobs:
               timestamp = $timestamp
               token = [System.Convert]::ToHexString($token).ToLower()
             }
+            Write-Output "Signing $_"
             Invoke-WebRequest -Uri $uri -Method Post -Form $form -OutFile signed.exe
-            Move-Item -Path signed.exe -Destination $_.Name -Force
+            Move-Item -Path signed.exe -Destination $_.FullName -Force
           }
 
       - name: Upload


### PR DESCRIPTION
### Problem

My code signing certificate recently expired. A hardware token (HSM) is now required for new certificates. For that reason, it's no longer possible to simply store the new code signing certificate (private key) in CI/CD secrets.

### Solution

I bought another YubiKey, which is one of the approved HSMs, and generated the new private key there. After the annoying verification process, the new code signing certificate was finally issued. This YubiKey is permanently plugged into Prophet, a server that I have at home. It now provides a secure web API endpoint for signing EXE files with the certificate (private key) stored in the YubiKey.

This PR adapts our CI/CD pipeline to use the code signing API instead of the old certificate.