### PR TITLE
Add HookSystemWarning + Fix logging in Client.lua

### DIFF
--- a/Code/Launcher/Launcher.cpp
+++ b/Code/Launcher/Launcher.cpp
@@ -741,6 +741,71 @@ static void HookNetworkGetService(void* pCryNetwork)
 	WinAPI::FillMem(&pCNetworkVTable[7], &reinterpret_cast<void*&>(pNewGetService), sizeof(void*));
 }
 
+struct DummyCSystem
+{
+	void Warning(int subsys, int severity, int flags, const char* file, const char* format, ...)
+	{
+		std::string msg;
+
+		// severity is ignored because the message is always supposed to be a warning
+
+		switch (subsys)
+		{
+			case VALIDATOR_MODULE_UNKNOWN:      msg += "[Unknown] ";      break;
+			case VALIDATOR_MODULE_RENDERER:     msg += "[Renderer] ";     break;
+			case VALIDATOR_MODULE_3DENGINE:     msg += "[3DEngine] ";     break;
+			case VALIDATOR_MODULE_AI:           msg += "[AI] ";           break;
+			case VALIDATOR_MODULE_ANIMATION:    msg += "[Animation] ";    break;
+			case VALIDATOR_MODULE_ENTITYSYSTEM: msg += "[EntitySystem] "; break;
+			case VALIDATOR_MODULE_SCRIPTSYSTEM: msg += "[ScriptSystem] "; break;
+			case VALIDATOR_MODULE_SYSTEM:       msg += "[System] ";       break;
+			case VALIDATOR_MODULE_SOUNDSYSTEM:  msg += "[SoundSystem] ";  break;
+			case VALIDATOR_MODULE_GAME:         msg += "[Game] ";         break;
+			case VALIDATOR_MODULE_MOVIE:        msg += "[Movie] ";        break;
+			case VALIDATOR_MODULE_EDITOR:       msg += "[Editor] ";       break;
+			case VALIDATOR_MODULE_NETWORK:      msg += "[Network] ";      break;
+			case VALIDATOR_MODULE_PHYSICS:      msg += "[Physics] ";      break;
+			case VALIDATOR_MODULE_FLOWGRAPH:    msg += "[FlowGraph] ";    break;
+			default:                            msg += "[?] ";            break;
+		}
+
+		if (flags & VALIDATOR_FLAG_FILE)    msg += "[File] ";
+		if (flags & VALIDATOR_FLAG_TEXTURE) msg += "[Texture] ";
+		if (flags & VALIDATOR_FLAG_SCRIPT)  msg += "[Script] ";
+		if (flags & VALIDATOR_FLAG_SOUND)   msg += "[Sound] ";
+		if (flags & VALIDATOR_FLAG_AI)      msg += "[AI] ";
+
+		va_list args;
+		va_start(args, format);
+		StringTools::FormatToV(msg, format, args);
+		va_end(args);
+
+		if (file)
+		{
+			msg += " [";
+			msg += file;
+			msg += "]";
+		}
+
+		CryLogWarning("%s", msg.c_str());
+	}
+};
+
+static void HookSystemWarning(void* pCrySystem)
+{
+	void** pCSystemVTable = static_cast<void**>(WinAPI::RVA(pCrySystem,
+#ifdef BUILD_64BIT
+		0x26ACF8
+#else
+		0x1BC5F8
+#endif
+	));
+
+	// vtable hook
+	auto pNewWarning = &DummyCSystem::Warning;
+	WinAPI::FillMem(&pCSystemVTable[21], &reinterpret_cast<void*&>(pNewWarning), sizeof(void*));
+}
+
 static void LogRealWindowsBuild(Logger& logger)
 {
 	void* kernel32 = WinAPI::DLL::Get("kernel32.dll");
@@ -1090,6 +1155,7 @@ void Launcher::PatchEngine()
 		MemoryPatch::CrySystem::HookCryWarning(m_dlls.pCrySystem, &OnCryWarning);
 
 		InstallEarlyEngineInitHook(m_dlls.pCrySystem);
+		HookSystemWarning(m_dlls.pCrySystem);
 
 		ReplaceCryPak(m_dlls.pCrySystem);
 		ReplaceStreamEngine(m_dlls.pCrySystem);

--- a/Pak/CryMP/Scripts/Client.lua
+++ b/Pak/CryMP/Scripts/Client.lua
@@ -46,7 +46,7 @@ function InitializeClient()
 
 	local function OnMasterResolved()
 		masters = _L.CPPAPI.GetMasters()
-		printf("$5[CryMP] Resolved masters:", #masters)
+		printf("$5[CryMP] Resolved masters:")
 		for i, master in pairs(masters) do
 			printf("$5[CryMP] - %s", master)
 		end
@@ -756,7 +756,7 @@ function InitializeClient()
 	return true
 end
 
-local err, res = pcall(InitializeClient)
-if err then
-	System.LogAlways("$4[CryMP] Failed to InitializeClient: %s", tostring(err))
+local ok, res = pcall(InitializeClient)
+if not ok then
+	System.LogAlways("$4[CryMP] Failed to InitializeClient: " .. tostring(res))
 end


### PR DESCRIPTION
The original idea was to hook `ISystem::Warning` to make it log with verbosity 0 instead of 2. However, there are still too many vanilla warnings coming from there, so the hook uses `CryLogWarning` (verbosity >= 2) instead of `CryLogWarningAlways`. That means the hook isn't really necessary in the end, but it might be handy and we will need the code in our own implementation of `System` (CrySystem) anyway.

It also revealed a small issue in Client.lua, which is now fixed.