### PR TITLE
Allow AI.RegisterWithAI in multiplayer

### DIFF
--- a/Code/Launcher/Launcher.cpp
+++ b/Code/Launcher/Launcher.cpp
@@ -1050,6 +1050,7 @@ void Launcher::PatchEngine()
 	if (m_dlls.pCryAction)
 	{
 		MemoryPatch::CryAction::AllowDX9ImmersiveMultiplayer(m_dlls.pCryAction);
+		MemoryPatch::CryAction::AllowMultiplayerRegisterWithAI(m_dlls.pCryAction);
 		MemoryPatch::CryAction::DisableBreakLog(m_dlls.pCryAction);
 		MemoryPatch::CryAction::DisableTimeOfDayLengthLowerLimit(m_dlls.pCryAction);
 		MemoryPatch::CryAction::HookCryWarning(m_dlls.pCryAction, &OnCryWarning);

--- a/Code/Launcher/MemoryPatch.cpp
+++ b/Code/Launcher/MemoryPatch.cpp
@@ -73,6 +73,18 @@ void MemoryPatch::CryAction::AllowDX9ImmersiveMultiplayer(void* pCryAction)
 }
 
 /**
+ * This makes the AI.RegisterWithAI Lua function work in multiplayer.
+ */
+void MemoryPatch::CryAction::AllowMultiplayerRegisterWithAI(void* pCryAction)
+{
+#ifdef BUILD_64BIT
+	FillNop(pCryAction, 0xEF401, 0x1F);
+#else
+	FillNop(pCryAction, 0xA79BA, 0x1A);
+#endif
+}
+
+/**
  * Disables useless "times out" log messages from break replicator.
  */
 void MemoryPatch::CryAction::DisableBreakLog(void* pCryAction)

--- a/Code/Launcher/MemoryPatch.h
+++ b/Code/Launcher/MemoryPatch.h
@@ -16,6 +16,7 @@ namespace MemoryPatch
 	namespace CryAction
 	{
 		void AllowDX9ImmersiveMultiplayer(void* pCryAction);
+		void AllowMultiplayerRegisterWithAI(void* pCryAction);
 		void DisableBreakLog(void* pCryAction);
 		void DisableTimeOfDayLengthLowerLimit(void* pCryAction);
 		void HookGameWarning(void* pCryAction, void (*handler)(const char* format, ...));


### PR DESCRIPTION
Even though the restriction preventing CryAISystem from working in multiplayer has already been removed, the `AI.RegisterWithAI` Lua function still didn't work. It's fixed now. The `AI` table functions are actually implemented in CryAction instead of CryAISystem.

Thanks to [akeeperctl](https://github.com/akeeperctl) for pointing out this issue!