### PR TITLE
Fix inaccessible user folder under Parallels VM on Apple macOS

### DIFF
--- a/Code/Library/PathTools.cpp
+++ b/Code/Library/PathTools.cpp
@@ -228,17 +228,28 @@ void PathTools::Normalize(std::string& path)
 {
 	std::string::size_type prefixLength = 0;
 
+	char targetSlash = '/';
+
 	if (path.length() >= 1 && IsSlash(path[0]))
 	{
-		// POSIX absolute path
-		// note that UNC paths are not supported
-		path[0] = '/';
-		prefixLength = 1;
+		if (path.length() >= 2 && path[0] == '\\' && path[1] == '\\')
+		{
+			// UNC path
+			// keep backslashes in UNC paths
+			targetSlash = '\\';
+			prefixLength = 2;
+		}
+		else
+		{
+			// POSIX absolute path
+			path[0] = targetSlash;
+			prefixLength = 1;
+		}
 	}
 	else if (path.length() >= 3 && IsAlpha(path[0]) && path[1] == ':' && IsSlash(path[2]))
 	{
 		// Windows absolute path
-		path[2] = '/';
+		path[2] = targetSlash;
 		prefixLength = 3;
 	}
 
@@ -268,7 +279,7 @@ void PathTools::Normalize(std::string& path)
 
 			if (goodLength > 2)
 			{
-				const auto prevSlashPos = path.rfind('/', goodLength - 2);
+				const auto prevSlashPos = path.rfind(targetSlash, goodLength - 2);
 				if (prevSlashPos != std::string::npos && prevSlashPos > prefixLength)
 				{
 					erasePos = prevSlashPos + 1;
@@ -287,14 +298,14 @@ void PathTools::Normalize(std::string& path)
 
 		if (nextSlashPos != std::string::npos)
 		{
-			path[nextSlashPos] = '/';
+			path[nextSlashPos] = targetSlash;
 			goodLength++;
 		}
 	}
 
 	// remove trailing slash
 	// but keep the first slash
-	if (path.length() > 1 && path.back() == '/')
+	if ((path.length() > 1 && path.back() == '/') || (path.length() > 2 && path.back() == '\\'))
 	{
 		path.pop_back();
 	}


### PR DESCRIPTION
Add UNC path support to `PathTools::Normalize` used by `CryPak::AdjustFileName`. It allows CryPak to access network shares (UNC paths), which is necessary to access the user folder when running under Windows in a Parallels VM on Apple macOS. In such setup, the Documents folder is shared between the Windows guest and the macOS host. On the Windows guest side, it's located in `\\psf\Home\Documents`.

The issue was that CryPak did not support UNC paths. Here is the problematic user folder path:

```
\\psf\Home\Documents\My Games\Crysis
```

It was incorrectly normalized into:

```
/psf/Home/Documents/My Games/Crysis
```

And it made everything in the user folder (config, maps, paks) inaccessible. This is now fixed.

Thanks to TunSalat for reporting this issue!