### PR TITLE
Fix broken Unicode conversions in HUD

### DIFF
--- a/Code/CryGame/HUD/HUD.cpp
+++ b/Code/CryGame/HUD/HUD.cpp
@@ -2996,8 +2996,8 @@ void CHUD::GetGPSPosition(wchar_t* szN, wchar_t* szW)
 	int iW3 = (iW - iW1 * 1000000 - iW2 * 10000) / 100;
 	int iW4 = (iW - iW1 * 1000000 - iW2 * 10000 - iW3 * 100);
 
-	wstring strNorth = LocalizeWithParams("@ui_N");
-	wstring strWest = LocalizeWithParams("@ui_W");
+	std::wstring strNorth = LocalizeWithParams("@ui_N");
+	std::wstring strWest = LocalizeWithParams("@ui_W");
 
 	CrySwprintf(szN, 32, L"%.2d\"%.2d'%.2d.%.2d %s", iN1, iN2, iN3, iN4, strNorth.c_str());
 	CrySwprintf(szW, 32, L"%.2d\"%.2d'%.2d.%.2d %s", iW1, iW2, iW3, iW4, strWest.c_str());
@@ -3709,7 +3709,7 @@ void CHUD::UpdateSpectator(CPlayer* pSpectatorTarget, float frameTime)
 		m_prevSpectatorMode = specMode;
 		m_prevSpectatorTarget = m_pClientActor->GetSpectatorTarget();
 
-		wstring mapText, functionalityText;
+		std::wstring mapText, functionalityText;
 		// don't want the 'press m to...' text if waiting to respawn
 		if (!m_pGameRules->IsPlayerActivelyPlaying(m_pClientActor->GetEntityId()))
 		{
@@ -3742,7 +3742,7 @@ void CHUD::UpdateSpectator(CPlayer* pSpectatorTarget, float frameTime)
 			}
 
 			// waiting to respawn - must be in 3rd person mode. Just show 'press left/right to switch player'
-			mapText = L"";
+			mapText.clear();
 			functionalityText = LocalizeWithParams("@ui_spectate_functionality_dead");
 		}
 		SFlashVarValue textArgs[3] = { mapText.c_str(), functionalityText.c_str(), true };
@@ -4606,11 +4606,9 @@ void CHUD::UpdateObjective(CHUDMissionObjective* pObjective)
 		{
 			if (!pObjective->IsSilent() /*&& pObjective->GetStatus() != CHUDMissionObjective::DEACTIVATED*/)
 			{
-				const wchar_t* localizedText = LocalizeWithParams(description.c_str());
-				wstring text = localizedText;
-				localizedText = LocalizeWithParams(status);
-				text.append(L" ");
-				text.append(localizedText);
+				std::wstring text = LocalizeWithParams(description.c_str());
+				text += L" ";
+				text += LocalizeWithParams(status);
 				SFlashVarValue args[3] = { text.c_str(), 1, Col_White.pack_rgb888() };
 				m_animMessages.Invoke("setMessageText", args, 3);
 				if (pObjective->GetStatus() == CHUDMissionObjective::COMPLETED)
@@ -5448,9 +5446,8 @@ void CHUD::GameOver(int localWinner, int winnerTeam, EntityId id)
 		}
 	}
 
-	const wchar_t* localizedText = L"";
-	localizedText = LocalizeWithParams(message, false, param);
-	m_animScoreBoard.Invoke("setWinText", localizedText);
+	std::wstring localizedText = LocalizeWithParams(message, false, param);
+	m_animScoreBoard.Invoke("setWinText", localizedText.c_str());
 
 	//SFlashVarValue args[2] = { localizedText, false };
 	//m_animMPMessages.Invoke("addKillLog", args, 2);

--- a/Code/CryGame/HUD/HUD.h
+++ b/Code/CryGame/HUD/HUD.h
@@ -397,7 +397,7 @@ public:
 	EntityId GetOnScreenObjective() {return m_iOnScreenObjective; }
 	bool IsUnderAttack(IEntity *pEntity);
 	ILINE CHUDMissionObjectiveSystem& GetMissionObjectiveSystem() { return m_missionObjectiveSystem; }
-	const wchar_t* LocalizeWithParams(const char* label, bool bAdjustActions=true, const char* param1 = 0, const char* param2 = 0, const char* param3 = 0, const char* param4 = 0);
+	std::wstring LocalizeWithParams(const char* label, bool bAdjustActions = true, const char* param1 = 0, const char* param2 = 0, const char* param3 = 0, const char* param4 = 0);
 	//~mission objectives
 
 	//BattleStatus code : consult Marco C.

--- a/Code/CryGame/HUD/HUDCrosshair.cpp
+++ b/Code/CryGame/HUD/HUDCrosshair.cpp
@@ -307,7 +307,8 @@ void CHUDCrosshair::SetUsability(int usable, const char* actionLabel, const char
 				}
 			}
 
-			m_animInterActiveIcons.Invoke("setText", m_pHUD->LocalizeWithParams(actionLabel, true, paramLocA.c_str(), paramLocB.c_str()));
+			std::wstring localized = m_pHUD->LocalizeWithParams(actionLabel, true, paramLocA.c_str(), paramLocB.c_str());
+			m_animInterActiveIcons.Invoke("setText", localized.c_str());
 		}
 		else
 		{

--- a/Code/CryGame/HUD/HUDInterfaceEffects.cpp
+++ b/Code/CryGame/HUD/HUDInterfaceEffects.cpp
@@ -1843,9 +1843,8 @@ void CHUD::ShowProgress(int progress, bool init /* = false */, int posX /* = 0 *
 		}
 
 		pAnim->Invoke("showProgressBar", true);
-		const wchar_t* localizedText = text.empty() ? L"" : LocalizeWithParams(text.data(), true);
-
-		SFlashVarValue args[2] = {localizedText, topText ? 1 : 2};
+		std::wstring localizedText = LocalizeWithParams(text.data(), true);
+		SFlashVarValue args[2] = {localizedText.c_str(), topText ? 1 : 2};
 		pAnim->Invoke("setText", args, 2);
 		SFlashVarValue pos[2] = {posX*1024/800, posY*768/512};
 		pAnim->Invoke("setPosition", pos, 2);

--- a/Code/CryGame/HUD/HUDPowerStruggle.cpp
+++ b/Code/CryGame/HUD/HUDPowerStruggle.cpp
@@ -197,7 +197,7 @@ void CHUDPowerStruggle::Update(float fDeltaTime)
 		_itoa(ihq[0], chq[0], 10);
 		_itoa(ihq[1], chq[1], 10);
 
-		wstring hqFormatter[2];
+		std::wstring hqFormatter[2];
 		hqFormatter[0] = g_pGame->GetHUD()->LocalizeWithParams("@mp_HQLife", false, chq[0]);
 		hqFormatter[1] = g_pGame->GetHUD()->LocalizeWithParams("@mp_HQLife", false, chq[1]);
 
@@ -1426,8 +1426,7 @@ void CHUDPowerStruggle::PopulateBuyList(bool clearEntitites)
 	char buffer[10];
 	itoa(m_lastPurchase.iPrice, buffer, 10);
 
-	wstring localized;
-	localized = g_pHUD->LocalizeWithParams("@ui_buy_REPEATLASTBUY", true, buffer);
+	std::wstring localized = g_pHUD->LocalizeWithParams("@ui_buy_REPEATLASTBUY", true, buffer);
 
 	g_pBuyMenu->Invoke("setLastPurchase", SFlashVarValue(localized.c_str()));
 

--- a/Code/CryGame/HUD/HUDTextChat.cpp
+++ b/Code/CryGame/HUD/HUDTextChat.cpp
@@ -267,7 +267,7 @@ void CHUDTextChat::AddChatMessage(const char* nick, const wchar_t* msg, int team
 
 	if (teamChat)
 	{
-		wstring nameAndTarget = m_pHUD->LocalizeWithParams("@ui_chat_team", true, nick);
+		std::wstring nameAndTarget = m_pHUD->LocalizeWithParams("@ui_chat_team", true, nick);
 		SFlashVarValue args[3] = { nameAndTarget.c_str(), msg, teamFaction };
 		m_flashChat->Invoke("setChatText", args, 3);
 	}
@@ -287,7 +287,7 @@ void CHUDTextChat::AddChatMessage(const char* nick, const char* msg, int teamFac
 
 	if (teamChat)
 	{
-		wstring nameAndTarget = m_pHUD->LocalizeWithParams("@ui_chat_team", true, nick);
+		std::wstring nameAndTarget = m_pHUD->LocalizeWithParams("@ui_chat_team", true, nick);
 		SFlashVarValue args[3] = { nameAndTarget.c_str(), msg, teamFaction };
 		m_flashChat->Invoke("setChatText", args, 3);
 	}

--- a/Code/CryGame/Menus/MPHub.cpp
+++ b/Code/CryGame/Menus/MPHub.cpp
@@ -19,6 +19,7 @@
 #include "OptionsManager.h"
 #include "FlashMenuObject.h"
 #include "CryCommon/CryRenderer/IVideoPlayer.h"
+#include "Library/StringTools.h"
 
 static TKeyValuePair<EGsUiCommand, const char*>
 gUiCommands[] = {
@@ -658,17 +659,6 @@ void CMPHub::SetLoginInfo(const char* nick)
 	}
 }
 
-void ExpandToWChar(const char* charString, wstring& outString)
-{
-	outString.resize(strlen(charString));
-	wchar_t* dst = outString.begin();
-	const char* src = charString;
-	while (const wchar_t c = (wchar_t)(*src++))
-	{
-		*dst++ = c;
-	}
-}
-
 void CMPHub::DisconnectError(EDisconnectionCause dc, bool connecting, const char* serverMsg/*=NULL*/)
 {
 	const char* msg = VALUE_BY_KEY(dc, gDisconnectErrors);
@@ -696,7 +686,7 @@ void CMPHub::DisconnectError(EDisconnectionCause dc, bool connecting, const char
 			{
 				wstring final;
 				wstring localised, tmp;
-				ExpandToWChar(serverMsg + 21, tmp);
+				StringTools::AppendTo(tmp, serverMsg + 21);
 				pLoc->LocalizeLabel(msg, localised);
 				wstring newstring = L"%1\n@{ui_reason}: %2";
 				pLoc->FormatStringMessage(final, newstring, localised.c_str(), tmp.c_str());
@@ -731,7 +721,7 @@ void CMPHub::DisconnectError(EDisconnectionCause dc, bool connecting, const char
 			if (strlen(serverMsg) > 21 && strncmp(serverMsg + 21, "None", 4) != 0)
 			{
 				wstring localised, tmp;
-				ExpandToWChar(serverMsg + 21, tmp);
+				StringTools::AppendTo(tmp, serverMsg + 21);
 				pLoc->LocalizeLabel(msg, localised);
 				pLoc->FormatStringMessage(final, localised, tmp.c_str());
 			}
@@ -755,7 +745,7 @@ void CMPHub::DisconnectError(EDisconnectionCause dc, bool connecting, const char
 			{
 				wstring final;
 				wstring localised, tmp;
-				ExpandToWChar(serverMsg, tmp);
+				StringTools::AppendTo(tmp, serverMsg);
 				pLoc->LocalizeLabel(msg, localised);
 				pLoc->FormatStringMessage(final, localised, tmp.c_str());
 


### PR DESCRIPTION
This PR fixes Unicode characters in player names shown as squares in **team** chat. Below are examples of the issue in the Japanese localization. There were still some broken wide-string conversions left. It's all fixed now. Plus some refactoring.

### Before

<img width="460" height="99" alt="image" src="https://github.com/user-attachments/assets/409735d5-fda7-4aaf-a58b-e42606c7381e" />

<img width="547" height="100" alt="image" src="https://github.com/user-attachments/assets/6c5f3b7f-54c1-4fe0-88bd-4355380a1871" />

### Now

<img width="415" height="91" alt="image" src="https://github.com/user-attachments/assets/8c45c014-6354-4233-82be-4e1ea15c7123" />

<img width="533" height="93" alt="image" src="https://github.com/user-attachments/assets/10c13d0a-608e-49a8-bb6a-6b24b2d0b35d" />
