### PR TITLE
Treat all compiler warnings as errors in the pipeline + other minor improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Build
         id: build
         run: |
+          $PSNativeCommandUseErrorActionPreference = $true
           $vs_path = & 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' `
             -latest -property installationPath
           Import-Module (Join-Path $vs_path 'Common7\Tools\Microsoft.VisualStudio.DevShell.dll')
@@ -44,7 +45,6 @@ jobs:
           Enter-VsDevShell -VsInstallPath $vs_path -SkipAutomaticLocation -Arch $arch
           cmake -S . -B $env:BUILD_DIR -G Ninja -D CMAKE_BUILD_TYPE=${{ inputs.type }}
           cmake --build $env:BUILD_DIR
-          $exe_path = Join-Path $env:BUILD_DIR 'CryMP-Client${{ inputs.bits }}.exe'
           $version = git describe --dirty --tags --match 'v*'
           'artifact_name=CryMP-Client${{ inputs.bits }}-' + $version >> $env:GITHUB_OUTPUT
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       artifact_name: ${{ steps.build.outputs.artifact_name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # for version generator
           fetch-depth: 0
@@ -71,7 +71,7 @@ jobs:
           }
 
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.build.outputs.artifact_name }}
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Build
         id: build
+        env:
+          CXXFLAGS: /WX
         run: |
           $PSNativeCommandUseErrorActionPreference = $true
           $vs_path = & 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' `

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,12 +25,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download 32-bit build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.artifact_32 }}
 
       - name: Download 64-bit build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.artifact_64 }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,15 +33,15 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download 32-bit build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ needs.build_32.outputs.artifact_name }}
 
       - name: Download 64-bit build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ needs.build_64.outputs.artifact_name }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -748,6 +748,8 @@ target_compile_options(Base PUBLIC /W4
 	/wd4245  # Disable - 'conversion' : conversion from 'type1' to 'type2', signed/unsigned mismatch
 	/wd4267  # Disable - 'var' : conversion from 'size_t' to 'type', possible loss of data
 	/wd4305  # Disable - 'conversion': truncation from 'type1' to 'type2'
+	/wd4324  # Disable - structure was padded due to alignment specifier
+	/wd4334  # Disable - '<<': result of 32-bit shift implicitly converted to 64 bits
 	/wd4456  # Disable - declaration of 'identifier' hides previous local declaration
 	/wd4458  # Disable - declaration of 'identifier' hides class member
 	/wd4702  # Disable - unreachable code

--- a/Code/CryAction/ItemSystem.cpp
+++ b/Code/CryAction/ItemSystem.cpp
@@ -2,6 +2,7 @@
 #include "CryCommon/CryAction/IGameplayRecorder.h"
 #include "CryCommon/CryAISystem/IAISystem.h"
 #include "CryCommon/CryAnimation/ICryAnimation.h"
+#include "CryCommon/CryCore/CryMalloc.h" // CryMalloc
 #include "CryCommon/CryEntitySystem/IEntitySystem.h"
 #include "CryCommon/CryScriptSystem/IScriptSystem.h"
 #include "CryCommon/CrySoundSystem/ISound.h"
@@ -294,7 +295,9 @@ void ItemSystem::Scan(const char* folderName)
 
 IItemParamsNode* ItemSystem::CreateParams()
 {
-	return new ItemParamsNode();
+	// use CryMalloc to match CryFree used by the original ItemParamsNode destructor
+	void* mem = CryMalloc(sizeof(ItemParamsNode));
+	return new (mem) ItemParamsNode;
 }
 
 const IItemParamsNode* ItemSystem::GetItemParams(const char* itemName) const

--- a/Code/CryCommon/CryAISystem/IAIRecorder.h
+++ b/Code/CryCommon/CryAISystem/IAIRecorder.h
@@ -27,8 +27,6 @@ struct IAIRecorder
 
 };
 
-class CStream;
-
 struct IAIDebugRecord;
 
 struct IAIRecordable

--- a/Code/CryCommon/CryAction/IVehicleSystem.h
+++ b/Code/CryCommon/CryAction/IVehicleSystem.h
@@ -21,6 +21,8 @@ History:
 #include <cstdint>
 #include <utility>
 
+#include "CryCommon/CryCore/CryMalloc.h" // CryMalloc
+#include "CryCommon/CryCore/CrySizer.h"
 #include "CryCommon/CryEntitySystem/IEntity.h"
 #include "CryCommon/CryEntitySystem/IEntitySystem.h"
 #include "CryCommon/CryScriptSystem/IScriptSystem.h"
@@ -1732,18 +1734,35 @@ struct IVehicleIterator
 };
 typedef _smart_ptr<IVehicleIterator> IVehicleIteratorPtr;
 
+// use CryMalloc to match CryFree used by original destructors in CryAction.dll
+#define DECLARE_GAMEOBJECT_FACTORY_VEHICLE_SYSTEM(impl) \
+public: \
+	virtual void RegisterFactory(const char* name, impl* (*)(), bool isAI) = 0; \
+	template <class T> void RegisterFactory(const char* name, impl*, bool isAI, T*) \
+	{ \
+		struct Factory \
+		{ \
+			static impl* Create() \
+			{ \
+				void* mem = CryMalloc(sizeof(T)); \
+				return new (mem) T; \
+			} \
+		}; \
+		RegisterFactory(name, Factory::Create, isAI); \
+	}
+
 // Summary:
 //   Vehicle System interface
 // Description:
 //   Interface used to implement the vehicle system. 
 struct IVehicleSystem
 {
-	DECLARE_GAMEOBJECT_FACTORY(IVehicleMovement);
-	DECLARE_GAMEOBJECT_FACTORY(IVehicleView);
-	DECLARE_GAMEOBJECT_FACTORY(IVehiclePart);
-	DECLARE_GAMEOBJECT_FACTORY(IVehicleDamageBehavior);
-	DECLARE_GAMEOBJECT_FACTORY(IVehicleSeatAction);
-	DECLARE_GAMEOBJECT_FACTORY(IVehicleAction);
+	DECLARE_GAMEOBJECT_FACTORY_VEHICLE_SYSTEM(IVehicleMovement);
+	DECLARE_GAMEOBJECT_FACTORY_VEHICLE_SYSTEM(IVehicleView);
+	DECLARE_GAMEOBJECT_FACTORY_VEHICLE_SYSTEM(IVehiclePart);
+	DECLARE_GAMEOBJECT_FACTORY_VEHICLE_SYSTEM(IVehicleDamageBehavior);
+	DECLARE_GAMEOBJECT_FACTORY_VEHICLE_SYSTEM(IVehicleSeatAction);
+	DECLARE_GAMEOBJECT_FACTORY_VEHICLE_SYSTEM(IVehicleAction);
 
 	virtual bool Init() = 0;
 	virtual void Release() = 0;

--- a/Code/CryCommon/CryCore/platform.h
+++ b/Code/CryCommon/CryCore/platform.h
@@ -16,29 +16,7 @@
 
 #pragma once
 
-// Temporary here
-#define _CRT_SECURE_NO_DEPRECATE
-#define _CRT_NONSTDC_NO_DEPRECATE
-
-// Debug STL turned off so we can use intermixed debug/release versions of DLL.
-//#undef _HAS_ITERATOR_DEBUGGING
-//#define _HAS_ITERATOR_DEBUGGING 0
-//#undef _SECURE_SCL
-//#define _SECURE_SCL 0
-
-#if defined(_DEBUG) && !defined(PS3) && !defined(LINUX)
-	#include <crtdbg.h>
-#endif
-
-//////////////////////////////////////////////////////////////////////////
-// Available predefined compiler macros for Visual C++.
-// _MSC_VER                   // Indicates MS Visual C compiler version
-// _WIN32, _WIN64, _XBOX_VER  // Indicates target OS
-// _M_IX86, _M_PPC            // Indicates target processor
-// _DEBUG                     // Building in Debug mode
-// _DLL                       // Linking with DLL runtime libs
-// _MT                        // Linking with multi-threaded runtime libs
-//////////////////////////////////////////////////////////////////////////
+#include <stdint.h>
 
 //
 // Translate some predefined macros.
@@ -111,12 +89,16 @@
 //////////////////////////////////////////////////////////////////////////
 // Platform: WIN23,WIN64,LINUX32,LINUX64,_XBOX
 //////////////////////////////////////////////////////////////////////////
+#ifdef _MSC_VER
 #define ILINE __forceinline
+#else
+#define ILINE inline
+#endif
 
+#ifdef _MSC_VER
 #define DEPRICATED __declspec(deprecated)
-
-#ifndef _WIN32_WINNT
-# define _WIN32_WINNT 0x501
+#else
+#define DEPRICATED
 #endif
 
 //////////////////////////////////////////////////////////////////////////
@@ -125,15 +107,17 @@
 typedef signed char         int8;
 typedef signed short        int16;
 typedef signed int          int32;
-typedef signed __int64      int64;
+typedef int64_t             int64;
 typedef unsigned char       uint8;
 typedef unsigned short      uint16;
 typedef unsigned int        uint32;
-typedef unsigned __int64    uint64;
+typedef uint64_t            uint64;
 typedef float               f32;
 typedef double              f64;
 typedef double              real;  //biggest float-type on this machine
 typedef unsigned long       DWORD;
+
+#ifdef _MSC_VER
 
 #ifdef WIN64
 typedef __int64 INT_PTR, *PINT_PTR;
@@ -147,6 +131,16 @@ typedef __w64 unsigned int UINT_PTR, *PUINT_PTR;
 
 typedef __w64 long LONG_PTR, *PLONG_PTR;
 typedef __w64 unsigned long ULONG_PTR, *PULONG_PTR;
+#endif
+
+#else
+
+typedef intptr_t INT_PTR, *PINT_PTR;
+typedef uintptr_t UINT_PTR, *PUINT_PTR;
+
+typedef intptr_t LONG_PTR, *PLONG_PTR;
+typedef uintptr_t ULONG_PTR, *PULONG_PTR;
+
 #endif
 
 typedef ULONG_PTR DWORD_PTR, *PDWORD_PTR;

--- a/Code/CryCommon/CryMath/Cry_Math.h
+++ b/Code/CryCommon/CryMath/Cry_Math.h
@@ -419,14 +419,10 @@ ILINE int8 float_to_ifrac8( float f )
 }
 
 
-static int32 inc_mod3[]={1,2,0}, dec_mod3[]={2,0,1};
-#ifdef PHYSICS_EXPORTS
+constexpr int32 inc_mod3[] = {1,2,0};
+constexpr int32 dec_mod3[] = {2,0,1};
 #define incm3(i) inc_mod3[i]
 #define decm3(i) dec_mod3[i]
-#else
-inline int32 incm3(int32 i) { return i+1 & (i-2)>>31; }
-inline int32 decm3(int32 i) { return i-1 + ((i-1)>>31&3); }
-#endif
 
 
 template<class F> inline F square(F fOp) { return(fOp*fOp); }

--- a/Code/CryCommon/CryMath/Cry_Math.h
+++ b/Code/CryCommon/CryMath/Cry_Math.h
@@ -20,12 +20,9 @@
 //========================================================================================
 
 #include "CryCommon/CryCore/platform.h"
+#include <float.h>
 #include <math.h>
 #include "Cry_ValidNumber.h"
-
-#ifdef LINUX
-#include <values.h>
-#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 // Forward declarations                                                      //

--- a/Code/CryCommon/CryMath/Cry_Vector3.h
+++ b/Code/CryCommon/CryMath/Cry_Vector3.h
@@ -829,7 +829,7 @@ template <typename F> struct Ang3_tpl
 	Ang3_tpl(type_zero) { x=y=z=0; }
 
 	void operator () ( F vx, F vy,F vz ) { x=vx; y=vy; z=vz; };
-	ILINE Ang3_tpl<F>( F vx, F vy, F vz )	{	x=vx; y=vy; z=vz;	}  
+	ILINE Ang3_tpl( F vx, F vy, F vz )	{	x=vx; y=vy; z=vz;	}
 
 	explicit ILINE Ang3_tpl(const Vec3_tpl<F>& v) : x((F)v.x), y((F)v.y), z((F)v.z) { assert(this->IsValid()); }
 

--- a/Code/CryCommon/CryMath/GeomQuery.h
+++ b/Code/CryCommon/CryMath/GeomQuery.h
@@ -13,8 +13,10 @@
 #ifndef GEOM_QUERY_H
 #define GEOM_QUERY_H
 
+#include "Cry_Math.h"
 #include "Cry_Geo.h"
 #include "CryCommon/CryCore/CryArray.h"
+#include "CryCommon/CrySystem/ISystem.h" // FSystemAlloc
 
 // Implementation for efficient repeated queries.
 struct GeomQuery
@@ -163,8 +165,6 @@ inline float BoxExtent(EGeomForm eForm, Vec3 const& vSize)
 {
 	switch (eForm)
 	{
-		default:
-			assert(0);
 		case GeomForm_Vertices:
 			return 8.f;
 		case GeomForm_Edges:
@@ -303,8 +303,6 @@ inline float TriExtent(EGeomForm eForm, Vec3 const& v0, Vec3 const& v1, Vec3 con
 {
 	switch (eForm)
 	{
-		default:
-			assert(0);
 		case GeomForm_Edges:
 			return (v1-v0).GetLength() + (v2-v1).GetLength() + (v0-v2).GetLength();
 		case GeomForm_Surface:

--- a/Code/CryCommon/CrySystem/IXml.h
+++ b/Code/CryCommon/CrySystem/IXml.h
@@ -236,8 +236,6 @@ public:
 	virtual void setAttr( const char* key,const Quat &value ) = 0;
 	//////////////////////////////////////////////////////////////////////////
 	// Inline Helpers.
-	void setAttr( const char* key,unsigned long value ) { setAttr( key,(unsigned int)value ); };
-	void setAttr( const char* key,long value ) { setAttr( key,(int)value ); };
 	void setAttr( const char* key,double value ) { setAttr( key,(float)value ); };
 	//////////////////////////////////////////////////////////////////////////
 
@@ -261,8 +259,6 @@ public:
 	virtual bool getAttr( const char *key,XmlString &value ) const = 0;
 	//////////////////////////////////////////////////////////////////////////
 	// Inline Helpers.
-	bool getAttr( const char *key,long &value ) const { int v; if (getAttr(key,v)) { value = v; return true; } else return false; }
-	bool getAttr( const char *key,unsigned long &value ) const { unsigned int v; if (getAttr(key,v)) { value = v; return true; } else return false; }
 	bool getAttr( const char *key,unsigned short &value ) const { unsigned int v; if (getAttr(key,v)) { value = v; return true; } else return false; }
 	bool getAttr( const char *key,unsigned char &value ) const { unsigned int v; if (getAttr(key,v)) { value = v; return true; } else return false; }
 	bool getAttr( const char *key,short &value ) const { int v; if (getAttr(key,v)) { value = v; return true; } else return false; }

--- a/Code/CryGame/Actors/Actor.cpp
+++ b/Code/CryGame/Actors/Actor.cpp
@@ -875,9 +875,9 @@ void CActor::SetActorModel()
 		{
 			//entity:LoadObject
 			const char* ext = CryPath::GetExt(m_frozenModel.c_str());
-			if (stricmp(ext, CRY_CHARACTER_FILE_EXT) == 0 ||
-				stricmp(ext, CRY_CHARACTER_DEFINITION_FILE_EXT) == 0 ||
-				stricmp(ext, CRY_ANIM_GEOMETRY_FILE_EXT) == 0)
+			if (_stricmp(ext, CRY_CHARACTER_FILE_EXT) == 0 ||
+				_stricmp(ext, CRY_CHARACTER_DEFINITION_FILE_EXT) == 0 ||
+				_stricmp(ext, CRY_ANIM_GEOMETRY_FILE_EXT) == 0)
 			{
 				GetEntity()->LoadCharacter(EntitySlot::FROZEN, m_frozenModel.c_str());
 			}

--- a/Code/CryGame/Actors/Player/NetPlayerInput.h
+++ b/Code/CryGame/Actors/Player/NetPlayerInput.h
@@ -29,7 +29,7 @@ public:
 	virtual void Reset();
 	virtual void DisableXI(bool disabled);
 
-	virtual void GetMemoryStatistics(ICrySizer * s) {s->Add(*this);}
+	virtual void GetMemoryStatistics(ICrySizer*) {}
 
 	virtual EInputType GetType() const
 	{

--- a/Code/CryGame/Actors/ScriptBind_Actor.cpp
+++ b/Code/CryGame/Actors/ScriptBind_Actor.cpp
@@ -1316,7 +1316,7 @@ int CScriptBind_Actor::GetClosestAttachment(IFunctionHandler* pH, int characterS
 	if (pDotChar)
 		*pDotChar = 0;
 
-	strlwr(attachmentName);
+	_strlwr(attachmentName);
 	//
 
 	return pH->EndFunction(attachmentName);

--- a/Code/CryGame/HUD/HUD.cpp
+++ b/Code/CryGame/HUD/HUD.cpp
@@ -903,13 +903,13 @@ void CHUD::GameRulesSet()
 
 	if (gEnv->bMultiplayer)
 	{
-		if (!stricmp(name.c_str(), "InstantAction"))
+		if (!_stricmp(name.c_str(), "InstantAction"))
 			gameRules = EHUD_INSTANTACTION;
-		else if (!stricmp(name.c_str(), "PowerStruggle"))
+		else if (!_stricmp(name.c_str(), "PowerStruggle"))
 			gameRules = EHUD_POWERSTRUGGLE;
-		else if (!stricmp(name.c_str(), "TeamAction"))
+		else if (!_stricmp(name.c_str(), "TeamAction"))
 			gameRules = EHUD_TEAMACTION;
-		else if (!stricmp(name.c_str(), "TeamInstantAction"))
+		else if (!_stricmp(name.c_str(), "TeamInstantAction"))
 			gameRules = EHUD_TEAMINSTANTACTION;
 	}
 

--- a/Code/CryGame/HUD/HUDPowerStruggle.cpp
+++ b/Code/CryGame/HUD/HUDPowerStruggle.cpp
@@ -1473,7 +1473,7 @@ void CHUDPowerStruggle::PopulateBuyList(bool clearEntitites)
 	ActivateBuyMenuTabs();
 
 	char buffer[10];
-	itoa(m_lastPurchase.iPrice, buffer, 10);
+	_itoa(m_lastPurchase.iPrice, buffer, 10);
 
 	std::wstring localized = g_pHUD->LocalizeWithParams("@ui_buy_REPEATLASTBUY", true, buffer);
 

--- a/Code/CryGame/HUD/HUDVehicleInterface.cpp
+++ b/Code/CryGame/HUD/HUDVehicleInterface.cpp
@@ -197,10 +197,10 @@ CHUDVehicleInterface::EVehicleHud CHUDVehicleInterface::ChooseVehicleHUD(IVehicl
 
 void CHUDVehicleInterface::OnEnterVehicle(IActor* pActor, const char* szVehicleClassName, const char* szSeatName)
 {
-	m_bParachute = (bool)(!strcmpi(szVehicleClassName, "Parachute"));
+	m_bParachute = (bool)(!_stricmp(szVehicleClassName, "Parachute"));
 	if (m_bParachute)
 	{
-		bool open = (bool)(!strcmpi(szSeatName, "Open"));
+		bool open = (bool)(!_stricmp(szSeatName, "Open"));
 		m_animStats.Reload();
 		assert(NULL == m_pVehicle);  // Attempt to enter in parachute while already in a vehicle!
 		m_animStats.Invoke("setActiveParachute", open);

--- a/Code/CryGame/Items/ItemParamReader.h
+++ b/Code/CryGame/Items/ItemParamReader.h
@@ -103,7 +103,7 @@ private:
 				if (node)
 				{
 					const char *nodeName = node->GetNameAttribute();
-					if (nodeName && nodeName[0] && !strcmpi(nodeName, name))
+					if (nodeName && nodeName[0] && !_stricmp(nodeName, name))
 						return node;
 				}
 			}

--- a/Code/CryGame/Items/ItemParams.cpp
+++ b/Code/CryGame/Items/ItemParams.cpp
@@ -600,7 +600,7 @@ bool CItem::ReadAccessoryAmmo(const IItemParamsNode *ammos)
 	for (int i=0; i<ammos->GetChildCount(); i++)
 	{
 		const IItemParamsNode *ammo = ammos->GetChild(i);
-		if (!strcmpi(ammo->GetName(), "ammo"))
+		if (!_stricmp(ammo->GetName(), "ammo"))
 		{
 			int amount=0;
 

--- a/Code/CryGame/Items/Weapons/AmmoParams.cpp
+++ b/Code/CryGame/Items/Weapons/AmmoParams.cpp
@@ -291,15 +291,15 @@ void SAmmoParams::LoadPhysics()
 	const char* typ = physics->GetAttribute("type");
 	if (typ)
 	{
-		if (!strcmpi(typ, "particle"))
+		if (!_stricmp(typ, "particle"))
 		{
 			physicalizationType = ePT_Particle;
 		}
-		else if (!strcmpi(typ, "rigid"))
+		else if (!_stricmp(typ, "rigid"))
 		{
 			physicalizationType = ePT_Rigid;
 		}
-		else if (!strcmpi(typ, "static"))
+		else if (!_stricmp(typ, "static"))
 		{
 			physicalizationType = ePT_Static;
 		}

--- a/Code/CryGame/Items/Weapons/Weapon.cpp
+++ b/Code/CryGame/Items/Weapons/Weapon.cpp
@@ -221,7 +221,7 @@ void CWeapon::InitFireModes(const IItemParamsNode* firemodes)
 		const IItemParamsNode* fm = firemodes->GetChild(k);
 		const char* typ = fm->GetAttribute("type");
 
-		if (typ && !strcmpi(typ, "default"))
+		if (typ && !_stricmp(typ, "default"))
 		{
 			m_fmDefaults = fm;
 			m_fmDefaults->AddRef();
@@ -244,7 +244,7 @@ void CWeapon::InitFireModes(const IItemParamsNode* firemodes)
 			continue;
 		}
 
-		if (!strcmpi(typ, "default"))
+		if (!_stricmp(typ, "default"))
 			continue;
 
 		if (!name || !name[0])
@@ -297,7 +297,7 @@ void CWeapon::InitZoomModes(const IItemParamsNode* zoommodes)
 		const IItemParamsNode* zm = zoommodes->GetChild(k);
 		const char* typ = zm->GetAttribute("type");
 
-		if (typ && !strcmpi(typ, "default"))
+		if (typ && !_stricmp(typ, "default"))
 		{
 			m_zmDefaults = zm;
 			m_zmDefaults->AddRef();
@@ -320,7 +320,7 @@ void CWeapon::InitZoomModes(const IItemParamsNode* zoommodes)
 			continue;
 		}
 
-		if (!strcmpi(typ, "default"))
+		if (!_stricmp(typ, "default"))
 			continue;
 
 		if (!name || !name[0])
@@ -388,7 +388,7 @@ void CWeapon::InitAmmos(const IItemParamsNode* ammos)
 	for (int i = 0; i < ammos->GetChildCount(); i++)
 	{
 		const IItemParamsNode* ammo = ammos->GetChild(i);
-		if (!strcmpi(ammo->GetName(), "ammo"))
+		if (!_stricmp(ammo->GetName(), "ammo"))
 		{
 			int extra = 0;
 			int amount = 0;

--- a/Code/CryGame/Menus/FlashMenuObject.cpp
+++ b/Code/CryGame/Menus/FlashMenuObject.cpp
@@ -736,7 +736,7 @@ bool CFlashMenuObject::OnInputEvent(const SInputEvent& rInputEvent)
 
 		if (ICVar* requireinputdevice = gEnv->pConsole->GetCVar("sv_requireinputdevice"))
 		{
-			if (!strcmpi(requireinputdevice->GetString(), "gamepad") && !m_iGamepadsConnected && !IsActive())
+			if (!_stricmp(requireinputdevice->GetString(), "gamepad") && !m_iGamepadsConnected && !IsActive())
 				ShowInGameMenu(true);
 		}
 
@@ -3065,7 +3065,7 @@ void CFlashMenuObject::OnPostUpdate(float fDeltaTime)
 
 	if (ICVar* requireinputdevice = gEnv->pConsole->GetCVar("sv_requireinputdevice"))
 	{
-		if (!strcmpi(requireinputdevice->GetString(), "gamepad") && !m_iGamepadsConnected && !IsActive())
+		if (!_stricmp(requireinputdevice->GetString(), "gamepad") && !m_iGamepadsConnected && !IsActive())
 			ShowInGameMenu(true);
 	}
 

--- a/Code/CryGame/ScriptControlledPhysics.cpp
+++ b/Code/CryGame/ScriptControlledPhysics.cpp
@@ -11,6 +11,7 @@ History:
 
 *************************************************************************/
 #include "CryCommon/CrySystem/ISystem.h"
+#include "CryCommon/CryCore/CrySizer.h"
 #include "CryCommon/CryCore/TArray.h"  // CLAMP
 #include "CryCommon/CryPhysics/IPhysics.h"
 #include "ScriptControlledPhysics.h"

--- a/Code/CryGame/Vehicles/Movement/VehicleMovementBase.cpp
+++ b/Code/CryGame/Vehicles/Movement/VehicleMovementBase.cpp
@@ -1620,7 +1620,7 @@ bool CVehicleMovementBase::IsProfilingMovement()
 
 	static ICVar* pDebugVehicle = gEnv->pConsole->GetCVar("v_debugVehicle");
 
-	if (g_pGameCVars->v_profileMovement && (m_pVehicle->IsPlayerDriving() || 0 == strcmpi(pDebugVehicle->GetString(), m_pVehicle->GetEntity()->GetName())))
+	if (g_pGameCVars->v_profileMovement && (m_pVehicle->IsPlayerDriving() || 0 == _stricmp(pDebugVehicle->GetString(), m_pVehicle->GetEntity()->GetName())))
 		return true;
 
 	return false;
@@ -2090,7 +2090,7 @@ void CVehicleMovementBase::DebugDraw(const float deltaTime)
 
 	while (g_pGameCVars->v_debugSounds)
 	{
-		if (!m_pVehicle->IsPlayerPassenger() && 0 != strcmpi(m_pVehicle->GetEntity()->GetName(), pDebugVehicle->GetString()))
+		if (!m_pVehicle->IsPlayerPassenger() && 0 != _stricmp(m_pVehicle->GetEntity()->GetName(), pDebugVehicle->GetString()))
 			break;
 
 		gEnv->pRenderer->Draw2dLabel(500, y, 1.5f, color, false, "vehicle rpm: %.2f", m_rpmScale);
@@ -2174,7 +2174,7 @@ void CVehicleMovementBase::DebugDraw(const float deltaTime)
 
 	while (g_pGameCVars->v_sprintSpeed != 0.f)
 	{
-		if (!m_pVehicle->IsPlayerPassenger() && 0 != strcmpi(m_pVehicle->GetEntity()->GetName(), pDebugVehicle->GetString()))
+		if (!m_pVehicle->IsPlayerPassenger() && 0 != _stricmp(m_pVehicle->GetEntity()->GetName(), pDebugVehicle->GetString()))
 			break;
 
 		float speed = m_pVehicle->GetStatus().speed;

--- a/Code/Launcher/Launcher.cpp
+++ b/Code/Launcher/Launcher.cpp
@@ -1334,7 +1334,7 @@ void Launcher::OnEarlyEngineInit(ISystem* pSystem)
 	logger.LogAlways("%s", banner);
 	logger.LogAlways("Compiled by " CRYMP_COMPILER);
 	logger.LogAlways("Copyright (C) 2001-2008 Crytek GmbH");
-	logger.LogAlways("Copyright (C) 2014-2025 CryMP");
+	logger.LogAlways("Copyright (C) 2014-2026 CryMP");
 	logger.LogAlways("");
 
 	logger.SetPrefix(logPrefix);

--- a/Code/Library/CrashLogger.cpp
+++ b/Code/Library/CrashLogger.cpp
@@ -82,23 +82,19 @@ static void DumpExceptionInfo(std::FILE* file, const EXCEPTION_RECORD* info)
 {
 	const unsigned int code = info->ExceptionCode;
 	const std::size_t address = reinterpret_cast<std::size_t>(info->ExceptionAddress);
+	std::size_t dataAddress = 0;
 
 	std::fprintf(file, "%s (0x%08X) at 0x" ADDR_FMT, ExceptionCodeToName(code), code, address);
 
 	if (code == EXCEPTION_ACCESS_VIOLATION || code == EXCEPTION_IN_PAGE_ERROR)
 	{
-		const std::size_t dataAddress = info->ExceptionInformation[1];
+		dataAddress = info->ExceptionInformation[1];
 
 		switch (info->ExceptionInformation[0])
 		{
 			case 0: std::fprintf(file, ": Read from 0x"  ADDR_FMT " failed", dataAddress); break;
 			case 1: std::fprintf(file, ": Write to 0x"   ADDR_FMT " failed", dataAddress); break;
 			case 8: std::fprintf(file, ": Execute at 0x" ADDR_FMT " failed", dataAddress); break;
-		}
-
-		if (g_heapInfoProvider)
-		{
-			g_heapInfoProvider(file, reinterpret_cast<void*>(dataAddress));
 		}
 	}
 	else if (code == CRASH_LOGGER_ENGINE_ERROR)
@@ -107,13 +103,15 @@ static void DumpExceptionInfo(std::FILE* file, const EXCEPTION_RECORD* info)
 
 		std::fprintf(file, ": %s", message);
 	}
-	else if (g_heapInfoProvider)
-	{
-		// let debug allocator log its error message
-		g_heapInfoProvider(file, nullptr);
-	}
 
 	std::fprintf(file, "\n");
+
+	if (g_heapInfoProvider)
+	{
+		// let debug allocator log its error message
+		g_heapInfoProvider(file, reinterpret_cast<void*>(dataAddress));
+	}
+
 	std::fflush(file);
 }
 

--- a/Resources/ClientLauncher.rc
+++ b/Resources/ClientLauncher.rc
@@ -24,7 +24,7 @@ BEGIN
 		BLOCK "040904E4"
 		BEGIN
 			VALUE "CompanyName",      "CryMP"
-			VALUE "LegalCopyright",   "(C) 2025 CryMP"
+			VALUE "LegalCopyright",   "(C) 2026 CryMP"
 			VALUE "ProductName",      "CryMP Client"
 			VALUE "ProductVersion",   CRYMP_VERSION_STRING
 			VALUE "FileVersion",      CRYMP_VERSION_STRING

--- a/Resources/ServerLauncher.rc
+++ b/Resources/ServerLauncher.rc
@@ -18,7 +18,7 @@ BEGIN
 		BLOCK "040904E4"
 		BEGIN
 			VALUE "CompanyName",      "CryMP"
-			VALUE "LegalCopyright",   "(C) 2025 CryMP"
+			VALUE "LegalCopyright",   "(C) 2026 CryMP"
 			VALUE "ProductName",      "CryMP Server"
 			VALUE "ProductVersion",   CRYMP_VERSION_STRING
 			VALUE "FileVersion",      CRYMP_VERSION_STRING

--- a/ThirdParty/openal-soft/common/ringbuffer.cpp
+++ b/ThirdParty/openal-soft/common/ringbuffer.cpp
@@ -43,8 +43,10 @@ auto RingBuffer::Create(std::size_t sz, std::size_t elem_sz, bool limit_writes) 
         power_of_two |= power_of_two>>4;
         power_of_two |= power_of_two>>8;
         power_of_two |= power_of_two>>16;
+#if defined(_MSC_VER) && defined(_WIN64) // fix warning C4293: '>>': shift count negative or too big
         if constexpr(sizeof(size_t) > sizeof(uint32_t))
             power_of_two |= power_of_two>>32;
+#endif
     }
     ++power_of_two;
     if(power_of_two < sz || power_of_two > std::numeric_limits<std::size_t>::max()>>1


### PR DESCRIPTION
- [Cleanup platform.h and fix compiler warnings](https://github.com/crymp-net/crymp-client/commit/5fa97c682e51a84849a23bbf374664558a5cd39f)
- [Bump year](https://github.com/crymp-net/crymp-client/commit/1d3aaeb9b4036f8d6d56da52a1efb107a132f7e0)
- [Improve debug allocator logs](https://github.com/crymp-net/crymp-client/commit/577e5299616f3d695d2906168604d13f87d3497f)
- [CI/CD: Bump versions of actions](https://github.com/crymp-net/crymp-client/commit/8a8b4945d296a0e459b81aefc6efcd734285b814)
- [CI/CD: Fix non-propagating build errors](https://github.com/crymp-net/crymp-client/commit/c6233fce9f4901106fabe0fae21cd78a7df1c985)
- [CI/CD: Treat all compiler warnings as errors](https://github.com/crymp-net/crymp-client/commit/4e1a88221c80250ac9dda896c464b4d03d5e310c)
- [Fix minor issues found by debug allocator](https://github.com/crymp-net/crymp-client/commit/15bd325b6b5cceb551b5a75f4845ba5b386e0f50)
- [Use inc_mod3 and dec_mod3 from CryPhysics globally](https://github.com/crymp-net/crymp-client/commit/b852bba7e2c07858a62a13363fb91a9eac1f7218)
- [Disable useless warnings C4324 and C4334 triggered by Lua code](https://github.com/crymp-net/crymp-client/commit/75c5904226ccd8444f107d48cf4476afc7465bfb)
- [Fix remaining compiler warnings](https://github.com/crymp-net/crymp-client/pull/420/commits/9569600b4c4f26a11d0f8a4fae8d0d7520c0545e)
- [Fix compiler warning in OpenAL-Soft in 32-bit build](https://github.com/crymp-net/crymp-client/pull/420/commits/388b7f3164313ab5ff9f37a84af520f8302add8f)