### PR TITLE
Fixed invisible FP weapon after parachute

### DIFF
--- a/Code/CryGame/Actors/Player/Player.cpp
+++ b/Code/CryGame/Actors/Player/Player.cpp
@@ -666,7 +666,22 @@ void CPlayer::UpdateFirstPersonEffects(float frameTime)
 
 				// deselect it
 				if (currentItem)
-					currentItem->PlayAction(g_pItemStrings->deselect, CItem::eIPAF_FirstPerson, false, CItem::eIPAF_Default | CItem::eIPAF_RepeatLastFrame);
+				{
+					// CryMP: Parachute forcibly switches to fists immediately.
+					// Do not leave the previous weapon blending/frozen in its FP deselect pose,
+					// because animation state is preserved across FP/TP switches.
+					currentItem->PlayAction(
+						g_pItemStrings->deselect,
+						CItem::eIPAF_FirstPerson,
+						false,
+						CItem::eIPAF_Default
+					);
+
+					if (ICharacterInstance* pChar = currentItem->GetEntity()->GetCharacter(CItem::eIGS_FirstPerson))
+					{
+						pChar->GetISkeletonAnim()->StopAnimationsAllLayers();
+					}
+				}
 				// schedule to start swimming after deselection is finished
 				pFists->EnableAnimations(false);
 				SelectItem(pFists->GetEntityId(), true);


### PR DESCRIPTION
### Fixes
- Fixed first-person weapons becoming invisible after parachute landing
  - Regression introduced by FP/TP animation persistence changes
  - Parachute forced a deselect using a frozen final animation frame
  - Previous weapon could remain stuck in an offscreen pose when reselected
  - Now clears FP animation state during parachute switch