### PR TITLE
Fix DOF blur not working in modify mode; use CPlayer DOF system

### DIFF
--- a/Code/CryGame/Actors/Player/Player.cpp
+++ b/Code/CryGame/Actors/Player/Player.cpp
@@ -122,32 +122,6 @@ static bool		m_merciTimeStarted = false;
 static bool		m_merciHealthUpdated = false;	//client only mercy time
 static float	m_merciTimeLastHit = 0.0f;
 
-//--------------------
-//this function will be called from the engine at the right time, since bones editing must be placed at the right time.
-int PlayerProcessBones(ICharacterInstance* pCharacter, void* player)
-{
-	//	return 1; //freezing and bone processing is not working very well.
-	CPlayer* pPlayer = static_cast<CPlayer*>(player);
-	const uint8 profile = pPlayer->GetPhysicsProfile();
-	if (pPlayer->GetEntity()->IsHidden() || profile == eAP_Ragdoll) //CryMP: IK not working with ragdolls, can be skipped
-	{
-		return 1;
-	}
-
-	const float timeFrame = gEnv->pTimer->GetFrameTime();
-
-	ISkeletonAnim* pISkeletonAnim = pCharacter->GetISkeletonAnim();
-	const uint32 numAnim = pISkeletonAnim->GetNumAnimsInFIFO(0);
-	if (numAnim)
-	{
-		//process bones specific stuff (IK, torso rotation, etc)
-		pPlayer->ProcessBonesRotation(pCharacter, timeFrame);
-	}
-
-	return 1;
-}
-//--------------------
-
 CPlayer::TAlienInterferenceParams CPlayer::m_interferenceParams;
 unsigned int CPlayer::s_ladderMaterial = 0;
 
@@ -243,7 +217,7 @@ CPlayer::~CPlayer()
 
 	ICharacterInstance* pCharacter = GetEntity()->GetCharacter(0);
 	if (pCharacter)
-		pCharacter->GetISkeletonPose()->SetPostProcessCallback0(0, 0);
+		pCharacter->GetISkeletonPose()->SetPostProcessCallback0(nullptr, nullptr);
 
 	if (m_pNanoSuit)
 		delete m_pNanoSuit;
@@ -4300,7 +4274,35 @@ void CPlayer::PostPhysicalize()
 	if (!pCharacter)
 		return;
 
-	pCharacter->GetISkeletonPose()->SetPostProcessCallback0(PlayerProcessBones, this);
+	//--------------------
+	//this function will be called from the engine at the right time, since bones editing must be placed at the right time.
+	pCharacter->GetISkeletonPose()->SetPostProcessCallback0(
+		[](ICharacterInstance* pCharacter, void* player) -> int
+		{
+			CPlayer* pPlayer = static_cast<CPlayer*>(player);
+			const uint8 profile = pPlayer->GetPhysicsProfile();
+
+			//CryMP: IK not working with ragdolls / frozen, can be skipped
+			if (pPlayer->GetEntity()->IsHidden() || profile == eAP_Ragdoll || profile == eAP_Frozen) 
+			{
+				return 1;
+			}
+
+			const float timeFrame = gEnv->pTimer->GetFrameTime();
+
+			ISkeletonAnim* pISkeletonAnim = pCharacter->GetISkeletonAnim();
+			const uint32 numAnim = pISkeletonAnim->GetNumAnimsInFIFO(0);
+			if (numAnim)
+			{
+				//process bones specific stuff (IK, torso rotation, etc)
+				pPlayer->ProcessBonesRotation(pCharacter, timeFrame);
+			}
+
+			return 1;
+		},
+		this
+	);
+
 	pe_simulation_params sim;
 	sim.maxLoggedCollisions = 5;
 	pe_params_flags flags;
@@ -8302,55 +8304,67 @@ void CPlayer::SetDofFxAmount(float amount, float speed)
 		m_dof_amount_speed = 0.0f;
 		m_current_dof_amount = amount;
 		m_target_dof_amount = amount;
-	}
 
+		ApplyDofFxAmount(amount);
+	}
+}
+
+void CPlayer::ApplyDofFxAmount(float amount)
+{
 	gEnv->p3DEngine->SetPostEffectParam("Dof_BlurAmount", amount);
 
 	if (amount <= 0.075f)
-	{
 		gEnv->p3DEngine->SetPostEffectParam("Dof_Active", 0);
-	}
 	else
-	{
 		gEnv->p3DEngine->SetPostEffectParam("Dof_Active", 1);
-	}
+}
+
+void CPlayer::ApplyDofFxLimits(float focusmin, float focusmax, float focuslim)
+{
+	gEnv->p3DEngine->SetPostEffectParam("Dof_FocusRange", -1);
+	gEnv->p3DEngine->SetPostEffectParam("Dof_FocusMin", focusmin);
+	gEnv->p3DEngine->SetPostEffectParam("Dof_FocusMax", focusmax);
+	gEnv->p3DEngine->SetPostEffectParam("Dof_FocusLimit", focuslim);
 }
 
 void CPlayer::ResetDofFx(float speed)
 {
-	if (speed)
+	if (speed > 0.0f)
 	{
 		m_dof_amount_speed = speed;
 		m_dof_distance_speed = speed;
+
 		m_target_dof_min = 0.0f;
-		m_target_dof_max = 2000.f;
-		m_target_dof_lim = 2500.f;
+		m_target_dof_max = 2000.0f;
+		m_target_dof_lim = 2500.0f;
 		m_target_dof_amount = 0.0f;
 	}
 	else
 	{
 		m_dof_amount_speed = 0.0f;
 		m_dof_distance_speed = 0.0f;
+
 		m_target_dof_min = 0.0f;
-		m_target_dof_max = 2000.f;
-		m_target_dof_lim = 2500.f;
+		m_target_dof_max = 2000.0f;
+		m_target_dof_lim = 2500.0f;
 		m_target_dof_amount = 0.0f;
+
 		m_current_dof_min = 0.0f;
-		m_current_dof_max = 2000.f;
-		m_current_dof_lim = 2500.f;
+		m_current_dof_max = 2000.0f;
+		m_current_dof_lim = 2500.0f;
 		m_current_dof_amount = 0.0f;
 
-		SetDofFxLimits(m_current_dof_min, m_current_dof_max, m_current_dof_lim);
-		SetDofFxAmount(0.0f);
+		ApplyDofFxLimits(m_current_dof_min, m_current_dof_max, m_current_dof_lim);
+		ApplyDofFxAmount(0.0f);
 	}
 }
 
 void CPlayer::UpdateDofFx(float frameTime)
 {
-	if (m_dof_amount_speed <= 0.0f)
-	{
-		ResetDofFx();
-	}
+	//if (m_dof_amount_speed <= 0.0f)
+	//{
+	//	ResetDofFx();
+	//}
 
 	// Update dof amount
 	float curr_dof_amt = m_current_dof_amount;
@@ -8359,7 +8373,7 @@ void CPlayer::UpdateDofFx(float frameTime)
 	if (curr_dof_amt != target_dof_amt)
 	{
 		m_current_dof_amount = DofInterpolate(curr_dof_amt, target_dof_amt, m_dof_amount_speed, frameTime);
-		SetDofFxAmount(m_current_dof_amount);
+		ApplyDofFxAmount(m_current_dof_amount);
 	}
 
 	// Update dof distances
@@ -8394,7 +8408,7 @@ void CPlayer::UpdateDofFx(float frameTime)
 
 	if (changelimits)
 	{
-		SetDofFxLimits(m_current_dof_min, m_current_dof_max, m_current_dof_lim);
+		ApplyDofFxLimits(m_current_dof_min, m_current_dof_max, m_current_dof_lim);
 	}
 }
 

--- a/Code/CryGame/Actors/Player/Player.h
+++ b/Code/CryGame/Actors/Player/Player.h
@@ -933,10 +933,6 @@ private:
 	void UpdateCharacter(ICharacterInstance* pCharacter, bool characterLoad = false);
 	void UpdateScreenFrost();
 	void UpdateScreenEffects(float frameTime);
-	void SetDofFxLimits(float focusmin, float focusmax, float focuslim, float speed = 0);
-	void SetDofFxMask(const char* texName);
-	void SetDofFxAmount(float amount, float speed = 0);
-	void ResetDofFx(float speed = 0);
 	void UpdateDofFx(float frameTime);
 	void SetMotionFxAmount(float amount, float speed = 0);
 	void SetMotionFxMask(const char* texName);
@@ -975,6 +971,14 @@ private:
 	Vec3 m_lefthandGrip = Vec3(ZERO);
 	Vec3 m_righthandGrip = Vec3(ZERO);
 	bool m_handGripsValid = false;
+
+public:
+	void SetDofFxLimits(float focusmin, float focusmax, float focuslim, float speed = 0);
+	void SetDofFxMask(const char* texName);
+	void SetDofFxAmount(float amount, float speed = 0);
+	void ApplyDofFxAmount(float amount);
+	void ApplyDofFxLimits(float focusmin, float focusmax, float focuslim);
+	void ResetDofFx(float speed = 0);
 
 private:
 

--- a/Code/CryGame/Items/Weapons/Weapon.cpp
+++ b/Code/CryGame/Items/Weapons/Weapon.cpp
@@ -57,9 +57,6 @@ CWeapon::CWeapon()
 	m_fire_alternation(false),
 	m_destination(0, 0, 0),
 	m_forcedHitMaterial(-1),
-	m_dofSpeed(0.0f),
-	m_dofValue(0.0f),
-	m_focusValue(0.0f),
 	m_currentViewMode(0),
 	m_useViewMode(false),
 	m_restartZoom(false),
@@ -850,24 +847,6 @@ void CWeapon::Update(SEntityUpdateContext& ctx, int update)
 	}
 
 	CItem::Update(ctx, update);
-
-
-	if (update == eIUS_General)
-	{
-		if (fabsf(m_dofSpeed) > 0.001f)
-		{
-			m_dofValue += m_dofSpeed * ctx.fFrameTime;
-			m_dofValue = CLAMP(m_dofValue, 0, 1);
-
-			//CryLogWarning("Actual DOF value = %f",m_dofValue);
-			if (m_dofSpeed < 0.0f)
-			{
-				m_focusValue -= m_dofSpeed * ctx.fFrameTime * 150.0f;
-				gEnv->p3DEngine->SetPostEffectParam("Dof_FocusLimit", 20.0f + m_focusValue);
-			}
-			gEnv->p3DEngine->SetPostEffectParam("Dof_BlurAmount", m_dofValue);
-		}
-	}
 }
 
 void CWeapon::PostUpdate(float frameTime)

--- a/Code/CryGame/Items/Weapons/Weapon.h
+++ b/Code/CryGame/Items/Weapons/Weapon.h
@@ -654,10 +654,6 @@ protected:
 
 	int										m_forcedHitMaterial;
 
-	float	m_dofValue;
-	float	m_dofSpeed;
-	float m_focusValue;
-
 	unsigned int m_timerLayerEnterId = 0;
 
 	Vec3 m_destination;

--- a/Code/CryGame/Items/Weapons/WeaponInput.cpp
+++ b/Code/CryGame/Items/Weapons/WeaponInput.cpp
@@ -319,45 +319,6 @@ bool CWeapon::OnActionSpecial(EntityId actorId, const ActionId& actionId, int ac
 	return true;
 }
 
-//------------------------------------------------------------------------
-class CWeapon::ScheduleLayer_Leave
-{
-public:
-	ScheduleLayer_Leave(CWeapon *wep)
-	{
-		_pWeapon = wep;
-	}
-	void execute(CItem *item) {
-		_pWeapon->m_transitioning = false;
-		gEnv->p3DEngine->SetPostEffectParam("Dof_Active", 0.0f);
-		_pWeapon->m_dofSpeed=0.0f;
-	}
-private:
-	CWeapon *_pWeapon;
-};
-
-class CWeapon::ScheduleLayer_Enter
-{
-public:
-	ScheduleLayer_Enter(CWeapon *wep)
-	{
-		_pWeapon = wep;
-	}
-	void execute(CItem *item) {
-		SAFE_HUD_FUNC(WeaponAccessoriesInterface(true));
-		//CryMP: Commented to fix weapon customization stuck when closing at certain point with right click
-		//_pWeapon->PlayLayer(g_pItemStrings->modify_layer, eIPAF_Default|eIPAF_NoBlend, false); 
-		_pWeapon->m_transitioning = false;
-
-		_pWeapon->m_timerLayerEnterId = 0;
-
-		gEnv->p3DEngine->SetPostEffectParam("Dof_BlurAmount", 1.0f);
-		_pWeapon->m_dofSpeed=0.0f;
-	}
-private:
-	CWeapon *_pWeapon;
-};
-
 //-------------------------------------------------------------------------
 bool CWeapon::OnActionModify(EntityId actorId, const ActionId& actionId, int activationMode, float value)
 {
@@ -383,10 +344,6 @@ bool CWeapon::OnActionModify(EntityId actorId, const ActionId& actionId, int act
 			StopLayer(g_pItemStrings->modify_layer, eIPAF_Default, false);
 			StopLayer(g_pItemStrings->enter_modify, eIPAF_Default, false); //CryMP
 
-			m_dofSpeed = -1.0f/((float)GetCurrentAnimationTime(eIGS_FirstPerson)/1000.0f);
-			m_dofValue = 1.0f;
-			m_focusValue = -1.0f;
-
 			const bool overrideBlend = m_timerLayerEnterId > 0;
 			if (m_timerLayerEnterId)
 			{
@@ -396,7 +353,32 @@ bool CWeapon::OnActionModify(EntityId actorId, const ActionId& actionId, int act
 
 			PlayAction(g_pItemStrings->leave_modify, 0, false, eIPAF_Default, -1.0f, overrideBlend ? 0.3f : -1.0f);
 
-			GetScheduler()->TimerAction(GetCurrentAnimationTime(eIGS_FirstPerson), CSchedulerAction<ScheduleLayer_Leave>::Create(this), false);
+			GetScheduler()->TimerAction(
+				GetCurrentAnimationTime(eIGS_FirstPerson),
+				MakeAction([this](CItem*)
+					{
+						this->m_transitioning = false;
+
+						CPlayer* pPlayer = this->GetOwnerPlayer();
+						if (pPlayer && pPlayer->IsClient())
+						{
+							pPlayer->ResetDofFx(0.0f);
+						}
+					}),
+				false
+			);
+
+			CPlayer* pPlayer = GetOwnerPlayer();
+			if (pPlayer && pPlayer->IsClient())
+			{
+				const float animTime = max(0.001f, (float)GetCurrentAnimationTime(eIGS_FirstPerson) / 1000.0f);
+				const float dofSpeed = 1.0f / animTime;
+
+				// Keep modify focus while fading blur out
+				pPlayer->SetDofFxLimits(0.0f, 5.0f, 20.0f, 0.0f);
+				pPlayer->SetDofFxAmount(0.0f, dofSpeed);
+			}
+
 			m_transitioning = true;
 
 			SAFE_HUD_FUNC(WeaponAccessoriesInterface(false));
@@ -407,20 +389,30 @@ bool CWeapon::OnActionModify(EntityId actorId, const ActionId& actionId, int act
 		else 
 		{
 			//open interface
-
-			gEnv->p3DEngine->SetPostEffectParam("Dof_Active", 1.0f);
-			gEnv->p3DEngine->SetPostEffectParam("Dof_FocusRange", -1.0f);
-			gEnv->p3DEngine->SetPostEffectParam("Dof_FocusMin", 0.0f);
-			gEnv->p3DEngine->SetPostEffectParam("Dof_FocusMax", 5.0f);
-			gEnv->p3DEngine->SetPostEffectParam("Dof_FocusLimit", 20.0f);
-			gEnv->p3DEngine->SetPostEffectParam("Dof_UseMask", 0.0f);
-
 			PlayAction(g_pItemStrings->enter_modify, 0, false, eIPAF_Default | eIPAF_RepeatLastFrame);
-			m_dofSpeed = 1.0f/((float)GetCurrentAnimationTime(eIGS_FirstPerson)/1000.0f);
-			m_dofValue = 0.0f;
+
+			CPlayer* pPlayer = GetOwnerPlayer();
+			if (pPlayer && pPlayer->IsClient())
+			{
+				pPlayer->SetDofFxMask(nullptr);
+				pPlayer->SetDofFxLimits(0.0f, 5.0f, 20.0f, 0.0f);
+				pPlayer->SetDofFxAmount(1.0f, 1.0f / ((float)GetCurrentAnimationTime(eIGS_FirstPerson) / 1000.0f));
+			}
+
 			m_transitioning = true;
 
-			m_timerLayerEnterId = GetScheduler()->TimerAction(GetCurrentAnimationTime(eIGS_FirstPerson), CSchedulerAction<ScheduleLayer_Enter>::Create(this), false);
+			m_timerLayerEnterId = GetScheduler()->TimerAction(
+				GetCurrentAnimationTime(eIGS_FirstPerson),
+				MakeAction([this](CItem*)
+					{
+						SAFE_HUD_FUNC(WeaponAccessoriesInterface(true));
+
+						this->m_transitioning = false;
+						this->m_timerLayerEnterId = 0;
+					}),
+				false
+			);
+
 			m_modifying = true;
 
 			GetGameObject()->InvokeRMI(CItem::SvRequestEnterModify(), CItem::EmptyParams(), eRMI_ToServer);


### PR DESCRIPTION
Closes #407

Fix DOF blur not working in modify mode; use CPlayer DOF system

- Fix DOF blur being overridden and not applied
- Use CPlayer DOF system (ported from Lua) instead of separate weapon logic
- Restore smooth blur fade when entering/exiting modify mode
- Fix missing DOF blur when ADS with iron sights and reflex sights
- Minor cleanup and removal of redundant DOF handling
- Replace scheduler helper classes with lambdas

