### PR TITLE
Replace remote held entity mass workaround with physics flag

### DIFF
--- a/Code/CryCommon/CryPhysics/physinterface.h
+++ b/Code/CryCommon/CryPhysics/physinterface.h
@@ -336,6 +336,8 @@ enum phentity_flags {
 	pef_override_impulse_scale=0x200000, pef_players_can_break=0x400000, pef_cannot_squash_players=0x10000000,
 	pef_ignore_areas=0x800000,
 	pef_log_state_changes=0x1000000, pef_log_collisions=0x2000000, pef_log_env_changes=0x4000000, pef_log_poststep=0x8000000,
+	//CryMP
+	pef_ignore_network_state = 0x20000000,
 };
 
 struct pe_params_flags : pe_params {

--- a/Code/CryGame/Items/Weapons/OffHand.cpp
+++ b/Code/CryGame/Items/Weapons/OffHand.cpp
@@ -4516,29 +4516,17 @@ void COffHand::HandleNewHeldEntity(const EntityId entityId, const bool isNewItem
 		UpdateEntityRenderFlags(entityId, EntityFpViewMode::ForceActive);
 	}
 
-	// Remote client in MP: mark client-only and zero mass while storing original mass on actor
+	// CryMP:
+	// Remote MP actors drive held objects through the attachment system.
+	// Ignore incoming rigid-body network state to prevent physics snapshots
+	// from fighting attachment transforms and removing local constraints.
 	if (gEnv->bClient && gEnv->bMultiplayer && pActor->IsRemote())
 	{
-		//pEntity->SetFlags(pEntity->GetFlags() | ENTITY_FLAG_CLIENT_ONLY);
-
 		if (IPhysicalEntity* pObjectPhys = pEntity->GetPhysics())
 		{
-			pe_status_dynamics dyn;
-			if (pObjectPhys->GetStatus(&dyn))
-			{
-				pe_simulation_params simParams;
-				simParams.mass = 0.0f;
-
-				const int success = pObjectPhys->SetParams(&simParams);
-				if (success)
-				{
-					m_heldEntityMassBackup = dyn.mass;
-				}
-				else
-				{
-					CryLogWarningAlways("Failed to set mass to 0 on object '%s'", pEntity->GetName());
-				}
-			}
+			pe_params_flags pf;
+			pf.flagsOR = pef_ignore_network_state;
+			pObjectPhys->SetParams(&pf);
 		}
 	}
 
@@ -4546,7 +4534,7 @@ void COffHand::HandleNewHeldEntity(const EntityId entityId, const bool isNewItem
 
 	if (pActor->IsThirdPerson())
 	{
-		if (CPlayer *pPlayer = CPlayer::FromActor(pActor))
+		if (CPlayer* pPlayer = CPlayer::FromActor(pActor))
 		{
 			if (!pPlayer->IsGrabTargetSet(entityId))
 			{
@@ -4591,36 +4579,17 @@ void COffHand::HandleOldHeldEntity(const EntityId oldHeldEntityId, const bool is
 				);
 			}
 		}
-	
-		// Remote client in MP: restore mass, clear client-only, rephys vehicles, clear cached mass
-		if (gEnv->bClient && gEnv->bMultiplayer && (!pActor || pActor->IsRemote())) //No actor: Actor disconnected
-		{
-			//pOldEntity->SetFlags(pOldEntity->GetFlags() & ~ENTITY_FLAG_CLIENT_ONLY);
 
+		// CryMP:
+		// Re-enable rigid-body network state now that the object is no longer
+		// attachment-driven by a remote actor.
+		if (gEnv->bClient && gEnv->bMultiplayer && (!pActor || pActor->IsRemote())) // No actor: actor disconnected
+		{
 			if (IPhysicalEntity* pObjectPhys = pOldEntity->GetPhysics())
 			{
-				pe_status_dynamics dyn;
-				pObjectPhys->GetStatus(&dyn);
-
-				const float originalMass = m_heldEntityMassBackup;
-				if (originalMass > 0.0f && dyn.mass != originalMass)
-				{
-					pe_simulation_params simParams;
-					simParams.mass = originalMass;
-					
-					const int success = pObjectPhys->SetParams(&simParams);
-					if (success == 0)
-					{
-						CryLogWarningAlways("Failed to restore mass on object '%s'", pOldEntity->GetName());
-					}
-					m_heldEntityMassBackup = 0.0f;
-				}
-			}
-			
-			if (IVehicle* pVehicle = m_pGameFramework->GetIVehicleSystem()->GetVehicle(pOldEntity->GetId()))
-			{
-				// CryMP: trigger rephysicalization to avoid bugs caused by 0 mass
-				reinterpret_cast<IGameObjectProfileManager*>(pVehicle + 1)->SetAspectProfile(eEA_Physics, 1);
+				pe_params_flags pf;
+				pf.flagsAND = ~pef_ignore_network_state;
+				pObjectPhys->SetParams(&pf);
 			}
 		}
 	}

--- a/Code/CryGame/Items/Weapons/OffHand.h
+++ b/Code/CryGame/Items/Weapons/OffHand.h
@@ -335,7 +335,6 @@ private:
 	unsigned int m_timerEnableCollisions = 0;
 	bool m_footAlignmentEnabled = true;
 	int m_heldVehicleCollisions = 0;
-	float m_heldEntityMassBackup = 0.0f;
 
 	struct SGripHitLocal
 	{

--- a/Code/CryPhysics/RigidEntity.cpp
+++ b/Code/CryPhysics/RigidEntity.cpp
@@ -4615,7 +4615,11 @@ int CRigidEntity::SetStateFromSnapshot(TSerialize ser, int flags)
 
 		float distance = m_pos.GetDistance(helper.pos);
 
-		if (m_body.Minv || ser.GetSerializationTarget() != eST_Network)
+		//CryMP
+		const bool ignoreNetState = ser.GetSerializationTarget() == eST_Network &&
+			(m_flags & pef_ignore_network_state);
+
+		if (!ignoreNetState && (m_body.Minv || ser.GetSerializationTarget() != eST_Network))
 		{
 			if (helper.simclass && ser.GetSerializationTarget() == eST_Network)
 			{


### PR DESCRIPTION
This update replaces the old mass `0` workaround used for remote held entities in multiplayer with a proper CryPhysics-side fix.

Previously, remote held objects had their mass temporarily set to `0` to stop incoming physics snapshots from fighting the attachment system. While this mostly worked, it could occasionally cause desync issues, floating objects, and vehicle physics problems that sometimes required forced rephysicalization after release.

This change adds a dedicated `pef_ignore_network_state` physics flag and integrates it into `CRigidEntity::SetStateFromSnapshot()`.

When the flag is enabled, incoming rigid-body network state is ignored while the object is attachment-driven by a remote player.

## Changes

* Added new `pef_ignore_network_state` physics flag
* Prevents incoming network physics snapshots from overriding attachment-driven transforms
* Fixed local ignore-buddy constraints being removed by network state restoration
* Replaced the old mass `0` workaround in `COffHand`
* Removed unnecessary vehicle rephysicalization workaround

## Result

Remote held entities and vehicles now behave correctly in multiplayer without needing temporary zero-mass physicalization.

