### PR TITLE
Fix crashes and hangs caused by oversized breakable grids

### DIFF
--- a/Code/CryCommon/CryPhysics/physinterface.h
+++ b/Code/CryCommon/CryPhysics/physinterface.h
@@ -1922,6 +1922,8 @@ struct PhysicsVars : SolverSettings {
 	float netMinSnapDot;
 	float netAngSnapMul;
 	float netSmoothTime;
+	//CryMP
+	int nMaxBreakableGridCells;
 };
 
 struct ray_hit {

--- a/Code/CryPhysics/BreakableGrid2d.cpp
+++ b/Code/CryPhysics/BreakableGrid2d.cpp
@@ -1,4 +1,5 @@
 #include "BreakableGrid2d.h"
+#include "CryCommon/CrySystem/ISystem.h"
 #include "Utils.h"
 
 int CBreakableGrid2d::get_neighb(int iTri, int iEdge)
@@ -26,6 +27,8 @@ void CBreakableGrid2d::get_edge_ends(int iTri, int iEdge, int& iend0, int& iend1
 
 void CBreakableGrid2d::Generate(vector2df* ptsrc, int npt, const vector2di& nCells, int bStaticBorder, int seed)
 {
+	m_disabled = false;
+
 	int i, j, ix, iy, ncells;
 	vector2df ptmin, ptmax, step, v0, v1;
 	vector2di sz;
@@ -40,6 +43,31 @@ void CBreakableGrid2d::Generate(vector2df* ptsrc, int npt, const vector2di& nCel
 	}
 
 	sz.set(nCells.x + 2, nCells.y + 3);
+
+	PhysicsVars* pVars = gEnv->pPhysicalWorld->GetPhysVars();
+
+	const int maxBreakableGridCells = max(1, pVars->nMaxBreakableGridCells);
+	const int generatedCells = sz.x * sz.y;
+
+	// CryMP: some custom maps generate extremely large breakable grids that can
+	// cause severe stalls during flood fill and chunk generation.
+	if (generatedCells > maxBreakableGridCells)
+	{
+		CryLogAlways(
+			"[BreakGrid] disabled huge grid: cells=%d max=%d size=(%d,%d) requested=(%d,%d)",
+			generatedCells,
+			maxBreakableGridCells,
+			sz.x,
+			sz.y,
+			nCells.x,
+			nCells.y
+		);
+
+		m_disabled = true;
+		m_nTris = 0;
+		return;
+	}
+
 	for (i = 1, ptmin = ptmax = ptsrc[0]; i < npt; i++)
 	{
 		ptmin = min(ptmin, ptsrc[i]);
@@ -182,8 +210,13 @@ void CBreakableGrid2d::Generate(vector2df* ptsrc, int npt, const vector2di& nCel
 int* CBreakableGrid2d::BreakIntoChunks(const vector2df& pt, float r, vector2df*& ptout, int maxPatchTris,
                                        float jointhresh, int seed)
 {
+	ptout = 0;
+
+	if (m_disabled)
+		return 0;
+
 	int i, j, nPatches, nSeedTris, nPatchTris, iTri, iTriNew, nCells, ihead, itail, szQueue, iEdge, iCurPatch, nVtx,
-	    nStaticTris, nUsedTris, ivtx[3], nTris, bStable;
+		nStaticTris, nUsedTris, ivtx[3], nTris, bStable;
 	// int iMotherPatch,bHasInclusions,iPatch;
 	vector2di sz = m_coord.size;
 	vector2df c, v0, v1;

--- a/Code/CryPhysics/BreakableGrid2d.cpp
+++ b/Code/CryPhysics/BreakableGrid2d.cpp
@@ -209,10 +209,10 @@ void CBreakableGrid2d::Generate(vector2df* ptsrc, int npt, const vector2di& nCel
 int* CBreakableGrid2d::BreakIntoChunks(const vector2df& pt, float r, vector2df*& ptout, int maxPatchTris,
                                        float jointhresh, int seed)
 {
-	ptout = 0;
+	ptout = nullptr;
 
 	if (m_disabled)
-		return 0;
+		return nullptr;
 
 	int i, j, nPatches, nSeedTris, nPatchTris, iTri, iTriNew, nCells, ihead, itail, szQueue, iEdge, iCurPatch, nVtx,
 		nStaticTris, nUsedTris, ivtx[3], nTris, bStable;

--- a/Code/CryPhysics/BreakableGrid2d.cpp
+++ b/Code/CryPhysics/BreakableGrid2d.cpp
@@ -53,8 +53,7 @@ void CBreakableGrid2d::Generate(vector2df* ptsrc, int npt, const vector2di& nCel
 	// cause severe stalls during flood fill and chunk generation.
 	if (generatedCells > maxBreakableGridCells)
 	{
-		CryLogAlways(
-			"[BreakGrid] disabled huge grid: cells=%d max=%d size=(%d,%d) requested=(%d,%d)",
+		CryLog("[BreakGrid] disabled huge grid: cells=%d max=%d size=(%d,%d) requested=(%d,%d)",
 			generatedCells,
 			maxBreakableGridCells,
 			sz.x,

--- a/Code/CryPhysics/BreakableGrid2d.h
+++ b/Code/CryPhysics/BreakableGrid2d.h
@@ -56,4 +56,6 @@ public:
 	int* m_pTris;
 	char* m_pCellDiv;
 	int m_nTris;
+
+	bool m_disabled = false;
 };

--- a/Code/CryPhysics/PhysicalWorld.cpp
+++ b/Code/CryPhysics/PhysicalWorld.cpp
@@ -249,6 +249,7 @@ void CPhysicalWorld::Init()
 	m_vars.netMinSnapDot = 0.99f;
 	m_vars.netAngSnapMul = 0.01f;
 	m_vars.netSmoothTime = 5.0f;
+	m_vars.nMaxBreakableGridCells = 50000;
 	m_iNextId = 1;
 	m_iNextIdDown = m_lastExtId = m_nExtIds = 0;
 	m_pEntsById = 0;

--- a/Code/CryPhysics/Utils.cpp
+++ b/Code/CryPhysics/Utils.cpp
@@ -2,6 +2,7 @@
 #include <cstdio> // std::snprintf
 
 #include "CryCommon/CryCore/MTPseudoRandom.h"
+#include "CryCommon/CrySystem/ISystem.h"
 
 #include "Qhull.h"
 #include "Utils.h"
@@ -2157,17 +2158,56 @@ int jgrid_checker::check_cell(const vector2di& icell, int& ilastcell)
 	return 0;
 }
 
-void jgrid_checker::MarkCellInterior(int i)
+// CryMP: replaced recursive flood fill with iterative traversal to prevent
+// stack overflows and long stalls on extremely large breakable grids.
+
+void jgrid_checker::MarkCellInterior(int start)
 {
-	int j, icell;
-	pCellMask[i] = 2;
-	for (j = 0; j < 4; j++)
+	if (!pgrid || !pCellMask)
+		return;
+
+	const int sx = pgrid->size.x;
+	const int sy = pgrid->size.y;
+
+	if (sx <= 0 || sy <= 0)
+		return;
+
+	const int cellCount = sx * sy;
+
+	if (start < 0 || start >= cellCount)
+		return;
+
+	if (pCellMask[start] & 2)
+		return;
+
+	std::vector<int> stack;
+	stack.reserve(1024);
+
+	pCellMask[start] = 2;
+	stack.push_back(start);
+
+	while (!stack.empty())
 	{
-		if (!(pCellMask[icell = i + vector2di((1 - (j & 2)) & -(j & 1), ((j & 2) - 1) & ~-(j & 1)) *
-		                                pgrid->stride] &
-		      2))
+		const int cell = stack.back();
+		stack.pop_back();
+
+		for (int dir = 0; dir < 4; ++dir)
 		{
-			MarkCellInterior(icell);
+			const vector2di ofs(
+				(1 - (dir & 2)) & -(dir & 1),
+				((dir & 2) - 1) & ~-(dir & 1)
+			);
+
+			const int next = cell + ofs * pgrid->stride;
+
+			if (next < 0 || next >= cellCount)
+				continue;
+
+			if (pCellMask[next] & 2)
+				continue;
+
+			pCellMask[next] = 2;
+			stack.push_back(next);
 		}
 	}
 }


### PR DESCRIPTION
- Fixed crashes and hangs caused by extremely large breakable grids on some custom maps
- Replaced recursive flood fill with an iterative version to avoid stack overflows
- Added a configurable limit for breakable grid size in PhysicsVars
- Disabled chunk generation for oversized breakable grids
- Improved stability when breaking problematic map objects