### PR TITLE
Fix articulated ragdolls freezing mid-air

### DIFF
--- a/Code/CryGame/Actors/Actor.cpp
+++ b/Code/CryGame/Actors/Actor.cpp
@@ -1471,17 +1471,6 @@ void CActor::Update(SEntityUpdateContext& ctx, int slot)
 	if (GetEntity()->IsHidden() && !(GetEntity()->GetFlags() & ENTITY_FLAG_UPDATE_HIDDEN))
 		return;
 
-	if (!IsClient() && GetPhysicsProfile() == eAP_Ragdoll)
-	{
-		IPhysicalEntity* pPhysics = GetEntity()->GetPhysics();
-		if (pPhysics)
-		{
-			pe_action_awake actionAwake;
-			actionAwake.bAwake = 1;
-			pPhysics->Action(&actionAwake);
-		}
-	}
-
 	if (m_sleepTimer > 0.0f && gEnv->bServer)
 	{
 		pe_status_dynamics dynStat;

--- a/Code/CryPhysics/PhysicalWorld.cpp
+++ b/Code/CryPhysics/PhysicalWorld.cpp
@@ -3135,8 +3135,32 @@ int CPhysicalWorld::RepositionEntity(CPhysicalPlaceholder* pobj, int flags, Vec3
 	if (flags & 2)
 	{
 		CPhysicalEntity* pent = (CPhysicalEntity*)pobj;
+
 		if (pent->m_iPrevSimClass != pent->m_iSimClass && pent->m_bPermanent + bQueued)
 		{
+			if (pent->GetType() == PE_ARTICULATED)
+			{
+				CArticulatedEntity* ae = (CArticulatedEntity*)pent;
+
+				// CryMP: Prevent player-sized articulated ragdolls from entering the sleeping sim class while airborne.
+				// The engine can sometimes request class 2 -> class 1 before the ragdoll is grounded, which freezes it mid-air.
+				// Grounded ragdolls are still allowed to sleep normally.
+				if (ae->m_iPrevSimClass == 2 &&
+					ae->m_iSimClass == 1 &&
+					!ae->m_bGrounded &&
+					ae->m_iSimTypeCur == 1 &&
+					ae->m_body.M > 40.0f &&
+					ae->m_nJoints >= 10 &&
+					ae->m_nParts >= 10)
+				{
+					ae->m_bAwake = 1;
+					ae->m_nSleepFrames = 0;
+					ae->m_iSimClass = 2;
+
+					return bGridLocked;
+				}
+			}
+
 			ChangeEntitySimClass(pent);
 			i = pent->m_iPrevSimClass;
 			pent->m_iPrevSimClass = pent->m_iSimClass;


### PR DESCRIPTION
## Changes

- Fixed player ragdolls occasionally freezing mid-air after death
- Moved the fix into the proper CryPhysics sim class place inside `RepositionEntity()`
- Prevent airborne ragdolls from transitioning from active (`2`) to sleeping (`1`) sim class
- Removed the previous workaround that force-kept ragdolls awake every frame in `CActor::Update`
- Grounded ragdolls still sleep normally and can be woken up by impacts/interactions