### PR TITLE
Fix crash in rigid projectile surface mapping

### DIFF
--- a/Code/CryCommon/CryPhysics/physinterface.h
+++ b/Code/CryCommon/CryPhysics/physinterface.h
@@ -253,7 +253,7 @@ struct pe_params_part : pe_params {	// Sets geometrical parameters of entity par
 	int idmatBreakable;
 	ITetrLattice *pLattice;
 	int *pMatMapping;
-	int nMats;
+	int nMats = 0;
 	int bAddrefGeoms;
 
 	VALIDATORS_START
@@ -275,7 +275,8 @@ struct pe_params_sensors : pe_params { // Attaches optional sensors to entity (s
 struct pe_simulation_params : pe_params { // Sets gravity and maximum time step
 	enum entype { type_id=10 };
 	pe_simulation_params() { type=type_id; MARK_UNUSED maxTimeStep,gravity,minEnergy,damping,iSimClass,
-		softness,softnessAngular,dampingFreefall,gravityFreefall,mass,density,maxLoggedCollisions; }
+		softness,softnessAngular,dampingFreefall,gravityFreefall,mass,density,softnessGroup,
+		softnessAngularGroup,maxLoggedCollisions; }
 
 	int iSimClass;
 	float maxTimeStep; // maximum time step that entity can accept (larger steps will be split)

--- a/Code/CryGame/Items/Weapons/Projectile.cpp
+++ b/Code/CryGame/Items/Weapons/Projectile.cpp
@@ -104,31 +104,44 @@ bool CProjectile::SetAspectProfile(EEntityAspects aspect, uint8 profile)
 		case ePT_Rigid:
 		{
 			SEntityPhysicalizeParams params;
+			memset(&params, 0, sizeof(params));
+
 			params.type = PE_RIGID;
 			params.mass = m_pAmmoParams->mass;
 			params.nSlot = 0;
 
 			GetEntity()->Physicalize(params);
 
-			pe_action_set_velocity velocity;
 			m_pPhysicalEntity = GetEntity()->GetPhysics();
-			velocity.w = spin;
-			m_pPhysicalEntity->Action(&velocity);
 
-			if (m_pAmmoParams->pSurfaceType)
+			if (m_pPhysicalEntity)
 			{
-				int sfid = m_pAmmoParams->pSurfaceType->GetId();
+				pe_action_set_velocity velocity;
+				memset(&velocity, 0, sizeof(velocity));
 
-				pe_params_part part;
-				part.ipart = 0;
+				velocity.w = spin;
+				m_pPhysicalEntity->Action(&velocity);
 
-				GetEntity()->GetPhysics()->GetParams(&part);
-				for (int i = 0; i < part.nMats; i++)
-					part.pMatMapping[i] = sfid;
+				if (m_pAmmoParams->pSurfaceType)
+				{
+					const int sfid = m_pAmmoParams->pSurfaceType->GetId();
+
+					pe_params_part part;
+					memset(&part, 0, sizeof(part));
+
+					part.ipart = 0;
+
+					if (m_pPhysicalEntity->GetParams(&part) && !is_unused(part.pMatMapping) && part.pMatMapping && part.nMats > 0)
+					{
+						for (int i = 0; i < part.nMats; ++i)
+						{
+							part.pMatMapping[i] = sfid;
+						}
+					}
+				}
 			}
 		}
 		break;
-
 		case ePT_Static:
 		{
 			SEntityPhysicalizeParams params;
@@ -168,12 +181,15 @@ bool CProjectile::SetAspectProfile(EEntityAspects aspect, uint8 profile)
 		if (m_pPhysicalEntity)
 		{
 			pe_simulation_params simulation;
+			memset(&simulation, 0, sizeof(simulation));
 			simulation.maxLoggedCollisions = m_pAmmoParams->maxLoggedCollisions;
 
 			pe_params_flags flags;
+			memset(&flags, 0, sizeof(flags));
 			flags.flagsOR = pef_log_collisions | (m_pAmmoParams->traceable ? pef_traceable : 0);
 
 			pe_params_part colltype;
+			memset(&colltype, 0, sizeof(colltype));
 			colltype.flagsAND = ~geom_colltype_explosion;
 
 			m_pPhysicalEntity->SetParams(&simulation);

--- a/Code/CryGame/Items/Weapons/Projectile.cpp
+++ b/Code/CryGame/Items/Weapons/Projectile.cpp
@@ -104,8 +104,6 @@ bool CProjectile::SetAspectProfile(EEntityAspects aspect, uint8 profile)
 		case ePT_Rigid:
 		{
 			SEntityPhysicalizeParams params;
-			memset(&params, 0, sizeof(params));
-
 			params.type = PE_RIGID;
 			params.mass = m_pAmmoParams->mass;
 			params.nSlot = 0;
@@ -117,8 +115,6 @@ bool CProjectile::SetAspectProfile(EEntityAspects aspect, uint8 profile)
 			if (m_pPhysicalEntity)
 			{
 				pe_action_set_velocity velocity;
-				memset(&velocity, 0, sizeof(velocity));
-
 				velocity.w = spin;
 				m_pPhysicalEntity->Action(&velocity);
 
@@ -127,8 +123,6 @@ bool CProjectile::SetAspectProfile(EEntityAspects aspect, uint8 profile)
 					const int sfid = m_pAmmoParams->pSurfaceType->GetId();
 
 					pe_params_part part;
-					memset(&part, 0, sizeof(part));
-
 					part.ipart = 0;
 
 					if (m_pPhysicalEntity->GetParams(&part) && !is_unused(part.pMatMapping) && part.pMatMapping && part.nMats > 0)
@@ -181,15 +175,12 @@ bool CProjectile::SetAspectProfile(EEntityAspects aspect, uint8 profile)
 		if (m_pPhysicalEntity)
 		{
 			pe_simulation_params simulation;
-			memset(&simulation, 0, sizeof(simulation));
 			simulation.maxLoggedCollisions = m_pAmmoParams->maxLoggedCollisions;
 
 			pe_params_flags flags;
-			memset(&flags, 0, sizeof(flags));
 			flags.flagsOR = pef_log_collisions | (m_pAmmoParams->traceable ? pef_traceable : 0);
 
 			pe_params_part colltype;
-			memset(&colltype, 0, sizeof(colltype));
 			colltype.flagsAND = ~geom_colltype_explosion;
 
 			m_pPhysicalEntity->SetParams(&simulation);


### PR DESCRIPTION
Fixed a crash caused by invalid material mapping access on rigid-body
projectiles. Added proper CryPhysics structure initialization and
validation before accessing pe_params_part data, preventing crashes
for explosives such as Claymores, C4, and AV Mines.