### PR TITLE
CryPhysics Stability Improvements

### DIFF
--- a/Code/CryPhysics/ChangeRequest.h
+++ b/Code/CryPhysics/ChangeRequest.h
@@ -103,57 +103,73 @@ struct ChangeRequest
 	T* m_pQueued = nullptr;
 
 	ChangeRequest(CPhysicalPlaceholder* pent, CPhysicalWorld* pWorld, T* params, int bInactive,
-	              void* ptrAux = nullptr, int iAux = 0)
-	    : m_pWorld(pWorld)
+		void* ptrAux = nullptr, int iAux = 0)
+		: m_pWorld(pWorld)
 	{
+		// CryMP: Some callers can still issue requests while the physical entity/world
+		// is already detached or being destroyed.
+		if (!pent || !pWorld)
+		{
+			return;
+		}
+
 		if (bInactive <= 0 && pent->m_iSimClass != 7)
 		{
 			if (m_pWorld->m_lockStep || m_pWorld->m_lockTPR || pent->m_bProcessed >= PENT_QUEUED ||
-			    bInactive < 0)
+				bInactive < 0)
 			{
 				subref* psubref;
 				int szSubref, szTot;
 				WriteLock lock(m_pWorld->m_lockQueue);
 				AtomicAdd(&pent->m_bProcessed, PENT_QUEUED);
+
 				for (psubref = GetSubref(params), szSubref = 0; psubref; psubref = psubref->next)
 				{
 					if (*(char**)((char*)params + psubref->iPtrOffs) &&
-					    !is_unused(*(char**)((char*)params + psubref->iPtrOffs)))
+						!is_unused(*(char**)((char*)params + psubref->iPtrOffs)))
 					{
 						szSubref += ((*(int*)((char*)params + max(0, psubref->iSzOffs)) &
-						              -psubref->iSzOffs >> 31) +
-						             psubref->iSzFixed) *
-						            psubref->iSzUnit;
+							-psubref->iSzOffs >> 31) +
+							psubref->iSzFixed) *
+							psubref->iSzUnit;
 					}
 				}
+
 				szTot = (sizeof(int) * 2) + sizeof(void*) + GetStructSize(params) + szSubref;
+
 				if (StructUsesAuxData(params))
 				{
 					szTot += sizeof(void*) + sizeof(int);
 				}
+
 				m_pWorld->AllocRequestsQueue(szTot);
 				m_pWorld->QueueData(GetStructId(params));
 				m_pWorld->QueueData(szTot);
 				m_pWorld->QueueData(pent);
+
 				if (StructUsesAuxData(params))
 				{
 					m_pWorld->QueueData(ptrAux);
 					m_pWorld->QueueData(iAux);
 				}
+
 				m_pQueued = (T*)m_pWorld->QueueData(params, GetStructSize(params));
+
 				for (psubref = GetSubref(params); psubref; psubref = psubref->next)
 				{
 					szSubref = ((*(int*)((char*)params + max(0, psubref->iSzOffs)) &
-					             -psubref->iSzOffs >> 31) +
-					            psubref->iSzFixed) *
-					           psubref->iSzUnit;
+						-psubref->iSzOffs >> 31) +
+						psubref->iSzFixed) *
+						psubref->iSzUnit;
+
 					if (*(char**)((char*)params + psubref->iPtrOffs) &&
-					    !is_unused(*(char**)((char*)params + psubref->iPtrOffs)))
+						!is_unused(*(char**)((char*)params + psubref->iPtrOffs)))
 					{
-						*(void**)((char*)m_pQueued + psubref->iPtrOffs) = m_pWorld->QueueData(
-						    *(char**)((char*)params + psubref->iPtrOffs), szSubref);
+						*(void**)((char*)m_pQueued + psubref->iPtrOffs) =
+							m_pWorld->QueueData(*(char**)((char*)params + psubref->iPtrOffs), szSubref);
 					}
 				}
+
 				OnStructQueued(params, pWorld, ptrAux, iAux);
 				m_bQueued = 1;
 			}
@@ -170,7 +186,14 @@ struct ChangeRequest
 		}
 	}
 
-	~ChangeRequest() { AtomicAdd(&m_pWorld->m_lockStep, -m_bLocked); }
+	~ChangeRequest()
+	{
+		// CryMP: Constructor can return early, so only unlock if a lock was actually taken.
+		if (m_pWorld && m_bLocked)
+		{
+			AtomicAdd(&m_pWorld->m_lockStep, -m_bLocked);
+		}
+	}
 
 	int IsQueued() { return m_bQueued; }
 

--- a/Code/CryPhysics/ParticleEntity.cpp
+++ b/Code/CryPhysics/ParticleEntity.cpp
@@ -712,6 +712,21 @@ int CParticleEntity::DoStep(float time_interval, int iCaller)
 					event.pEntity[1] = hits[j].pCollider;
 					event.pForeignData[1] = pCollider->m_pForeignData;
 					event.iForeignData[1] = pCollider->m_iForeignData;
+
+					// CryMP start: Some collision/raycast paths can occasionally return an invalid part index
+					// (or collide with entities that currently have no parts). Validate before
+					// accessing m_parts[ipart] or calling functions that expect a valid part.
+					if (pCollider->m_nParts <= 0)
+					{
+						continue;
+					}
+
+					if ((unsigned int)hits[j].ipart >= (unsigned int)pCollider->m_nParts)
+					{
+						continue;
+					}
+					// CryMP end
+
 					RigidBody* pbody = pCollider->GetRigidBody(hits[j].ipart);
 					event.vloc[1] = pbody->v + (pbody->w ^ event.pt - pbody->pos);
 					event.mass[1] = pbody->M;

--- a/Code/CryPhysics/PhysicalWorld.cpp
+++ b/Code/CryPhysics/PhysicalWorld.cpp
@@ -3019,7 +3019,7 @@ void CPhysicalWorld::ChangeEntitySimClass(CPhysicalEntity* pent)
 	{
 		const int list = actualOldList;
 
-		if ((unsigned int)list >= 8u)
+		if (list < 0 || list > 7)
 		{
 			CryLogAlways(
 				"[PhysicalWorld] ChangeEntitySimClass: invalid actualOldList=%d pent=%p",

--- a/Code/CryPhysics/PhysicalWorld.cpp
+++ b/Code/CryPhysics/PhysicalWorld.cpp
@@ -5490,7 +5490,8 @@ float CPhysicalWorld::PrimitiveWorldIntersection(int itype, primitives::primitiv
 
 int CPhysicalWorld::RayTraceEntity(IPhysicalEntity* pient, Vec3 origin, Vec3 dir, ray_hit* pHit, pe_params_pos* pp)
 {
-	if (!(dir.len2() > 0 && origin.len2() >= 0))
+	// CryMP: reject invalid input before creating ray geometry or dereferencing pointers.
+	if (!pient || !pHit || !origin.IsValid() || !dir.IsValid() || !(dir.len2() > 0.0f))
 	{
 		return 0;
 	}
@@ -5501,21 +5502,40 @@ int CPhysicalWorld::RayTraceEntity(IPhysicalEntity* pient, Vec3 origin, Vec3 dir
 	float scale = 1.0f;
 	CRayGeom aray(origin, dir);
 	geom_world_data gwd;
-	geom_contact* pcontacts;
 	intersection_params ip;
-	pHit->dist = 1E10;
+
+	// CryMP: Intersect writes contacts through this pointer; original code used an uninitialized pointer.
+	geom_contact contactsBuf[64];
+	geom_contact* pcontacts = contactsBuf;
+
+	pHit->dist = 1E10f;
+	pHit->pCollider = 0;
+	pHit->ipart = 0;
+	pHit->partid = 0;
+	pHit->surface_idx = -1;
+	pHit->idmatOrg = -1;
+	pHit->foreignIdx = -1;
+	pHit->pt.zero();
+	pHit->n.zero();
 
 	if (((CPhysicalPlaceholder*)pient)->m_iSimClass != 5)
 	{
 		CPhysicalEntity* pent = ((CPhysicalPlaceholder*)pient)->GetEntity();
+		if (!pent)
+		{
+			return 0;
+		}
+
 		if (pp)
 		{
 			pos = pp->pos;
 			qrot = pp->q;
+
 			if (!is_unused(pp->scale))
 			{
 				scale = pp->scale;
 			}
+
 			get_xqs_from_matrices(pp->pMtx3x4, pp->pMtx3x3, pos, qrot, scale);
 		}
 		else
@@ -5523,30 +5543,45 @@ int CPhysicalWorld::RayTraceEntity(IPhysicalEntity* pient, Vec3 origin, Vec3 dir
 			pos = pent->m_pos;
 			qrot = pent->m_qrot;
 		}
+
 		for (i = 0; i < pent->m_nParts; i++)
 		{
-			//(pent->m_qrot*pent->m_parts[i].q).getmatrix(gwd.R);	//Q2M_IVO
+			if (!pent->m_parts[i].pPhysGeom || !pent->m_parts[i].pPhysGeom->pGeom)
+			{
+				continue;
+			}
+
 			gwd.R = Matrix33(qrot * pent->m_parts[i].q);
 			gwd.offset = pos + qrot * pent->m_parts[i].pos;
 			gwd.scale = scale * pent->m_parts[i].scale;
+
+			pcontacts = contactsBuf;
 			ncont = pent->m_parts[i].pPhysGeom->pGeom->Intersect(&aray, &gwd, 0, &ip, pcontacts);
+
+			if (ncont > (int)(sizeof(contactsBuf) / sizeof(contactsBuf[0])))
+			{
+				ncont = (int)(sizeof(contactsBuf) / sizeof(contactsBuf[0]));
+			}
+
 			WriteLockCond lockColl(*ip.plock, 0);
 			lockColl.SetActive(isneg(-ncont));
-			for (; ncont > 0 && pcontacts[ncont - 1].t < pHit->dist && pcontacts[ncont - 1].n * dir > 0;
-			     ncont--)
-				;
+
+			for (; ncont > 0 && pcontacts[ncont - 1].t < pHit->dist && pcontacts[ncont - 1].n * dir > 0; ncont--)
+			{
+			}
+
 			if (ncont > 0)
 			{
-				pHit->dist = pcontacts[ncont - 1].t;
+				const geom_contact& contact = pcontacts[ncont - 1];
+
+				pHit->dist = contact.t;
 				pHit->pCollider = pent;
-				pHit->partid = pent->m_parts[pHit->ipart = i].id;
-				pHit->surface_idx = pent->GetMatId(pcontacts[ncont - 1].id[0], i);
-				pHit->idmatOrg = pcontacts[ncont - 1].id[0] +
-				                 (pent->m_parts[i].surface_idx + 1 & pcontacts[ncont - 1].id[0] >> 31);
-				pHit->foreignIdx =
-				    pent->m_parts[i].pPhysGeom->pGeom->GetForeignIdx(pcontacts[ncont - 1].iPrim[0]);
-				pHit->pt = pcontacts[ncont - 1].pt;
-				pHit->n = pcontacts[ncont - 1].n;
+				pHit->partid = pent->m_parts[i].id;
+				pHit->surface_idx = pent->GetMatId(contact.id[0], i);
+				pHit->idmatOrg = contact.id[0] + (pent->m_parts[i].surface_idx + 1 & contact.id[0] >> 31);
+				pHit->foreignIdx = pent->m_parts[i].pPhysGeom->pGeom->GetForeignIdx(contact.iPrim[0]);
+				pHit->pt = contact.pt;
+				pHit->n = contact.n;
 			}
 		}
 	}
@@ -5555,7 +5590,7 @@ int CPhysicalWorld::RayTraceEntity(IPhysicalEntity* pient, Vec3 origin, Vec3 dir
 		return ((CPhysArea*)pient)->RayTrace(origin, dir, pHit, pp);
 	}
 
-	return isneg(pHit->dist - 1E9);
+	return isneg(pHit->dist - 1E9f);
 }
 
 CPhysicalEntity* CPhysicalWorld::CheckColliderListsIntegrity()

--- a/Code/CryPhysics/PhysicalWorld.cpp
+++ b/Code/CryPhysics/PhysicalWorld.cpp
@@ -1,6 +1,7 @@
 #include "CryCommon/CryCore/MTPseudoRandom.h"
 #include "CryCommon/CryNetwork/ISerialize.h"
 #include "CryCommon/CrySystem/ISystem.h"
+#include "CryCommon/CryEntitySystem/IEntitySystem.h"
 
 #include "ArticulatedEntity.h"
 #include "BoxGeom.h"
@@ -2886,6 +2887,35 @@ void CPhysicalWorld::TimeStep(float time_interval, int flags)
 	}
 }
 
+int CPhysicalWorld::FindTypedListOwner(CPhysicalEntity* pent)
+{
+	if (!pent)
+	{
+		return -1;
+	}
+
+	for (int list = 0; list < 8; ++list)
+	{
+		int count = 0;
+
+		for (CPhysicalEntity* p = m_pTypedEnts[list]; p; p = p->m_next)
+		{
+			if (++count > 100000)
+			{
+				CryLogAlways("FindTypedListOwner: loop detected list=%d head=%p pent=%p", list, m_pTypedEnts[list], pent);
+				return -1;
+			}
+
+			if (p == pent)
+			{
+				return list;
+			}
+		}
+	}
+
+	return -1;
+}
+
 void CPhysicalWorld::DetachEntityGridThunks(CPhysicalPlaceholder* pobj)
 {
 	if (pobj->m_iGThunk0)
@@ -2924,62 +2954,157 @@ void CPhysicalWorld::DetachEntityGridThunks(CPhysicalPlaceholder* pobj)
 void CPhysicalWorld::ChangeEntitySimClass(CPhysicalEntity* pent)
 {
 	WriteLock lock(m_lockList);
-	if ((unsigned int)pent->m_iPrevSimClass < 8u)
+
+	if (!pent)
 	{
+		return;
+	}
+
+	const int oldClass = pent->m_iPrevSimClass;
+	const int newClass = pent->m_iSimClass;
+
+	if ((unsigned int)newClass >= 8u)
+	{
+		CryLogAlways(
+			"[PhysicalWorld] ChangeEntitySimClass: invalid newClass pent=%p old=%d new=%d",
+			pent,
+			oldClass,
+			newClass);
+		return;
+	}
+
+	const int actualOldList = FindTypedListOwner(pent);
+
+	if (actualOldList == newClass)
+	{
+		IEntity* pEntity = 0;
+		const char* pName = "<none>";
+		const char* pClass = "<none>";
+
+		if (pent->m_iForeignData == PHYS_FOREIGN_ID_ENTITY && pent->m_pForeignData)
+		{
+			pEntity = static_cast<IEntity*>(pent->m_pForeignData);
+			pName = pEntity->GetName();
+
+			if (pEntity->GetClass())
+			{
+				pClass = pEntity->GetClass()->GetName();
+			}
+		}
+
+		CryLogAlways(
+			"[PhysicalWorld] ChangeEntitySimClass: already in target list "
+			"ent=%s class=%s id=%d "
+			"pent=%p old=%d actual=%d new=%d perm=%d",
+			pName,
+			pClass,
+			pent->m_id,
+			pent,
+			oldClass,
+			actualOldList,
+			newClass,
+			pent->m_bPermanent);
+
+		pent->m_iPrevSimClass = newClass;
+
+		for (int ithunk = pent->m_iGThunk0; ithunk; ithunk = m_gthunks[ithunk].inextOwned)
+		{
+			m_gthunks[ithunk].iSimClass = newClass;
+		}
+
+		return;
+	}
+
+	if (actualOldList >= 0)
+	{
+		const int list = actualOldList;
+
+		if ((unsigned int)list >= 8u)
+		{
+			CryLogAlways(
+				"[PhysicalWorld] ChangeEntitySimClass: invalid actualOldList=%d pent=%p",
+				list,
+				pent);
+			return;
+		}
+
 		if (pent->m_next)
 		{
 			pent->m_next->m_prev = pent->m_prev;
 		}
-		(pent->m_prev ? pent->m_prev->m_next : m_pTypedEnts[pent->m_iPrevSimClass]) = pent->m_next;
-		if (pent == m_pTypedEntsPerm[pent->m_iPrevSimClass])
+
+		if (pent->m_prev)
 		{
-			m_pTypedEntsPerm[pent->m_iPrevSimClass] = pent->m_next;
+			pent->m_prev->m_next = pent->m_next;
+		}
+		else
+		{
+			m_pTypedEnts[list] = pent->m_next;
+		}
+
+		if (pent == m_pTypedEntsPerm[list])
+		{
+			m_pTypedEntsPerm[list] = pent->m_next;
 		}
 	}
 
+	pent->m_next = 0;
+	pent->m_prev = 0;
+
 	if (!pent->m_bPermanent)
 	{
-		pent->m_next = m_pTypedEnts[pent->m_iSimClass];
+		pent->m_next = m_pTypedEnts[newClass];
 		pent->m_prev = 0;
+
 		if (pent->m_next)
 		{
 			pent->m_next->m_prev = pent;
 		}
-		m_pTypedEnts[pent->m_iSimClass] = pent;
+
+		m_pTypedEnts[newClass] = pent;
 	}
 	else
 	{
-		pent->m_next = m_pTypedEntsPerm[pent->m_iSimClass];
-		if (m_pTypedEntsPerm[pent->m_iSimClass])
+		pent->m_next = m_pTypedEntsPerm[newClass];
+
+		if (m_pTypedEntsPerm[newClass])
 		{
-			pent->m_prev = m_pTypedEntsPerm[pent->m_iSimClass]->m_prev;
+			pent->m_prev = m_pTypedEntsPerm[newClass]->m_prev;
+
 			if (pent->m_prev)
 			{
 				pent->m_prev->m_next = pent;
 			}
+
 			pent->m_next->m_prev = pent;
 		}
-		else if (m_pTypedEnts[pent->m_iSimClass])
+		else if (m_pTypedEnts[newClass])
 		{
-			for (pent->m_prev = m_pTypedEnts[pent->m_iSimClass]; pent->m_prev && pent->m_prev->m_next;
-			     pent->m_prev = pent->m_prev->m_next)
+			for (pent->m_prev = m_pTypedEnts[newClass];
+				pent->m_prev && pent->m_prev->m_next;
+				pent->m_prev = pent->m_prev->m_next)
 				;
+
 			pent->m_prev->m_next = pent;
 		}
 		else
 		{
 			pent->m_prev = 0;
 		}
-		if (m_pTypedEntsPerm[pent->m_iSimClass] == m_pTypedEnts[pent->m_iSimClass])
+
+		if (m_pTypedEntsPerm[newClass] == m_pTypedEnts[newClass])
 		{
-			m_pTypedEnts[pent->m_iSimClass] = pent;
+			m_pTypedEnts[newClass] = pent;
 		}
-		m_pTypedEntsPerm[pent->m_iSimClass] = pent;
+
+		m_pTypedEntsPerm[newClass] = pent;
 	}
+
+	pent->m_iPrevSimClass = newClass;
 
 	for (int ithunk = pent->m_iGThunk0; ithunk; ithunk = m_gthunks[ithunk].inextOwned)
 	{
-		m_gthunks[ithunk].iSimClass = pent->m_iSimClass;
+		m_gthunks[ithunk].iSimClass = newClass;
 	}
 }
 

--- a/Code/CryPhysics/PhysicalWorld.h
+++ b/Code/CryPhysics/PhysicalWorld.h
@@ -156,6 +156,7 @@ public:
 	                      CPhysicalEntity* pPetitioner = 0, int szListPrealoc = 0, int iCaller = 0);
 	void ChangeEntitySimClass(CPhysicalEntity* pent);
 	int RepositionEntity(CPhysicalPlaceholder* pobj, int flags = 3, Vec3* BBox = 0, int bQueued = 0);
+	int FindTypedListOwner(CPhysicalEntity* pent);
 	void DetachEntityGridThunks(CPhysicalPlaceholder* pobj);
 	void ScheduleForStep(CPhysicalEntity* pent);
 	CPhysicalEntity* CheckColliderListsIntegrity();


### PR DESCRIPTION
# CryPhysics Stability Improvements

This PR adds a number of defensive fixes to improve CryPhysics stability and reduce crashes caused by invalid or inconsistent runtime state.

## Changes

* **Prevent invalid particle collision part access**

  * Added validation before accessing particle collision parts to prevent out-of-bounds access and invalid pointer dereferences.

* **Guard invalid physics change requests**

  * Added safety checks around physics state changes and queued requests to avoid invalid operations that could corrupt internal physics state.

* **Add `RayTraceEntity` safety validation**

  * Added validation for input parameters (entity, geometry pointers, hit buffer, etc.) before performing ray intersection tests.
  * Prevents crashes caused by invalid entities or malformed ray trace requests.

* **Improve typed entity list handling**

  * Improved `ChangeEntitySimClass()` by validating an entity's actual typed-list ownership instead of relying only on its previous simulation class.
  * Helps prevent duplicate list insertion and typed-list corruption, which could eventually lead to crashes during physics updates.

## Testing

These changes have been tested extensively using the CryMP pickup stress test, repeatedly picking up and dropping every physical object on the map across multiple clients over long multiplayer sessions.

During testing, the typed entity list fix successfully eliminated a rare list corruption issue that had previously resulted in physics crashes. These changes have significantly improved overall stability.

