### PR TITLE
Sync with c1-launcher v8

### DIFF
--- a/Code/CryAction/ItemSystem.cpp
+++ b/Code/CryAction/ItemSystem.cpp
@@ -296,7 +296,8 @@ void ItemSystem::Scan(const char* folderName)
 IItemParamsNode* ItemSystem::CreateParams()
 {
 	// use CryMalloc to match CryFree used by the original ItemParamsNode destructor
-	void* mem = CryMalloc(sizeof(ItemParamsNode));
+	std::size_t allocatedSize = 0;
+	void* mem = CryMalloc(sizeof(ItemParamsNode), allocatedSize);
 	return new (mem) ItemParamsNode;
 }
 

--- a/Code/CryCommon/Cry3DEngine/IIndexedMesh.h
+++ b/Code/CryCommon/Cry3DEngine/IIndexedMesh.h
@@ -604,7 +604,8 @@ public:
 private:
 	void *ReAllocElements(void *old_ptr,int new_elem_num, int size_of_element)
 	{
-		return CryRealloc(old_ptr,new_elem_num*size_of_element);
+		std::size_t allocatedSize = 0;
+		return CryRealloc(old_ptr,new_elem_num*size_of_element,allocatedSize);
 	}
 };
 

--- a/Code/CryCommon/CryAction/IVehicleSystem.h
+++ b/Code/CryCommon/CryAction/IVehicleSystem.h
@@ -1744,7 +1744,8 @@ public: \
 		{ \
 			static impl* Create() \
 			{ \
-				void* mem = CryMalloc(sizeof(T)); \
+				std::size_t allocatedSize = 0; \
+				void* mem = CryMalloc(sizeof(T), allocatedSize); \
 				return new (mem) T; \
 			} \
 		}; \

--- a/Code/CryCommon/CryCore/CryArray.h
+++ b/Code/CryCommon/CryCore/CryArray.h
@@ -15,17 +15,8 @@ struct FModuleAlloc
 {
 	static void* Alloc( void* oldptr, size_t oldsize, size_t newsize )
 	{
-		if (newsize)
-		{
-			return (oldptr) ? CryRealloc(oldptr, newsize) : CryMalloc(newsize);
-		}
-
-		if (oldptr)
-		{
-			CryFree(oldptr);
-		}
-
-		return 0;
+		std::size_t allocatedSize = 0;
+		return CryRealloc(oldptr, newsize, allocatedSize);
 	}
 };
 
@@ -380,7 +371,8 @@ struct FModuleAlloc16
     }
     if (newsize)
     {
-      unsigned char *pData = (unsigned char *)CryMalloc(newsize+16+sizeof(char *)+sizeof(DynArray<char>::Header));
+      std::size_t allocSize = 0;
+      unsigned char *pData = (unsigned char *)CryMalloc(newsize+16+sizeof(char *)+sizeof(DynArray<char>::Header), allocSize);
       unsigned char *bPtrRes = (unsigned char *)((ptrdiff_t)(pData+16+sizeof(char *)) & ~0xf);
       ((unsigned char**)bPtrRes)[-1] = pData;
       if (oldptr)

--- a/Code/CryCommon/CryCore/CryFixedString.h
+++ b/Code/CryCommon/CryCore/CryFixedString.h
@@ -597,7 +597,8 @@ inline void CryStackStringT<T,S>::_AllocData( size_type nLen )
 		value_type* pData = m_strBuf;
 		if (allocLen > MAX_SIZE)
 		{
-			pData = (value_type*) CryMalloc(allocLen);
+			std::size_t allocatedSize = 0;
+			pData = (value_type*) CryMalloc(allocLen, allocatedSize);
 			_usedMemory( allocLen ); // For statistics.
 			m_nAllocSize = nLen;
 		}

--- a/Code/CryCommon/CryCore/CryMalloc.h
+++ b/Code/CryCommon/CryCore/CryMalloc.h
@@ -2,6 +2,14 @@
 
 #include <cstddef>
 
-void* CryMalloc(std::size_t size);
-void* CryRealloc(void* oldPtr, std::size_t newSize);
-void CryFree(void* ptr);
+// CryMalloc functions exported by the EXE are automatically used instead of CrySystem.dll ones
+#ifdef _MSC_VER
+#define CRYMALLOC_API extern "C" __declspec(dllexport)
+#else
+#define CRYMALLOC_API
+#endif
+
+// Implemented in Code/CrySystem/CryMemoryManager.cpp
+CRYMALLOC_API void* CryMalloc(std::size_t size, std::size_t& allocatedSize);
+CRYMALLOC_API void* CryRealloc(void* oldPtr, std::size_t newSize, std::size_t& allocatedSize);
+CRYMALLOC_API std::size_t CryFree(void* ptr);

--- a/Code/CryCommon/CryCore/CryPodArray.h
+++ b/Code/CryCommon/CryCore/CryPodArray.h
@@ -109,7 +109,8 @@ public:
     {
       assert(&p<m_pElements || &p>=(m_pElements+m_nAllocatedCount));
       m_nAllocatedCount = m_nCount*2 + 8;
-      m_pElements = (T*)CryRealloc(m_pElements,m_nAllocatedCount*sizeof(T));
+      std::size_t allocatedSize = 0;
+      m_pElements = (T*)CryRealloc(m_pElements,m_nAllocatedCount*sizeof(T),allocatedSize);
       assert(m_pElements);
     }
 
@@ -131,7 +132,8 @@ public:
     {
       m_nAllocatedCount = elem_count;
 
-      T * new_elements = (T*)CryMalloc(m_nAllocatedCount*sizeof(T));
+      std::size_t allocatedSize = 0;
+      T * new_elements = (T*)CryMalloc(m_nAllocatedCount*sizeof(T), allocatedSize);
       assert(new_elements);
       memset(new_elements, 0, sizeof(T)*m_nAllocatedCount);
       memcpy(new_elements, m_pElements, sizeof(T)*m_nCount);

--- a/Code/CryCommon/CryCore/CryString.h
+++ b/Code/CryCommon/CryCore/CryString.h
@@ -614,7 +614,8 @@ inline void CryStringT<T>::_AllocData( size_type nLen )
 	else
 	{
 		size_type allocLen = sizeof(StrHeader) + (nLen+1)*sizeof(value_type);
-		StrHeader* pData = (StrHeader*) CryMalloc(allocLen);
+		std::size_t allocatedSize = 0;
+		StrHeader* pData = (StrHeader*) CryMalloc(allocLen, allocatedSize);
 
 		_usedMemory( allocLen ); // For statistics.
 

--- a/Code/CryCommon/CryCore/TArray.h
+++ b/Code/CryCommon/CryCore/TArray.h
@@ -92,7 +92,8 @@ public:
 	// puts the pointer to the actually allocated block before the aligned memory block
 	pointer allocate (size_type _Count)
 	{
-		pointer p = (pointer)CryMalloc(0x10+_Count*sizeof(T));
+		std::size_t allocatedSize = 0;
+		pointer p = (pointer)CryMalloc(0x10+_Count*sizeof(T), allocatedSize);
 		pointer pResult = (pointer)(((UINT_PTR)p+0x10)&~0xF);
 		// save the offset to the actual allocated address behind the useable aligned address
 		reinterpret_cast<int*>(pResult)[-1] = (char*)p - (char*)pResult;
@@ -224,7 +225,8 @@ public:
 			m_pElements = NULL;
 		else
 		{
-			m_pElements = (T *)CryRealloc(m_pElements, m_nAllocatedCount*sizeof(T));
+			std::size_t allocatedSize = 0;
+			m_pElements = (T *)CryRealloc(m_pElements, m_nAllocatedCount*sizeof(T), allocatedSize);
 			assert (m_pElements);
 		}
   }

--- a/Code/CryCommon/CryRenderer/IShader.h
+++ b/Code/CryCommon/CryRenderer/IShader.h
@@ -495,7 +495,8 @@ public:
   // - and we need to store only the offset, not the actual pointer
   void* operator new( size_t Size )
   {
-    unsigned char *ptr = (unsigned char *)CryMalloc(Size+16+4);
+    std::size_t allocatedSize = 0;
+    unsigned char *ptr = (unsigned char *)CryMalloc(Size+16+4, allocatedSize);
     memset(ptr, 0, Size+16+4);
     unsigned char *bPtrRes = (unsigned char *)((INT_PTR)(ptr+4+16) & ~0xf);
     ((unsigned char**)bPtrRes)[-1] = ptr;
@@ -508,7 +509,8 @@ public:
   }
   void* operator new[](size_t Size)
   {
-    unsigned char *ptr = (unsigned char *)CryMalloc(Size+16+2*sizeof(INT_PTR));
+    std::size_t allocatedSize = 0;
+    unsigned char *ptr = (unsigned char *)CryMalloc(Size+16+2*sizeof(INT_PTR), allocatedSize);
     memset(ptr, 0, Size+16+2*sizeof(INT_PTR));
     unsigned char *bPtrRes = (unsigned char *)((INT_PTR)(ptr+16+2*sizeof(INT_PTR)) & ~0xf);
     ((unsigned char**)bPtrRes)[-2] = ptr;

--- a/Code/CrySystem/CryMemoryManager.cpp
+++ b/Code/CrySystem/CryMemoryManager.cpp
@@ -1,4 +1,5 @@
-#include <array>
+#include <atomic>
+#include <cinttypes>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -37,6 +38,57 @@ static char g_fault_message[256];
 	// summon crash logger to pickup our message and log the callstack etc.
 	__debugbreak();
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// Statistics
+////////////////////////////////////////////////////////////////////////////////
+
+struct Stats
+{
+	std::atomic_uint64_t mallocCalls{};
+	std::atomic_uint64_t reallocCalls{};
+	std::atomic_uint64_t freeCalls{};
+	std::atomic_uint64_t sizeCalls{};
+	std::atomic_uint64_t crtMallocCalls{};
+	std::atomic_uint64_t crtFreeCalls{};
+
+	std::atomic_uint64_t safePoolBlocks{};
+	std::atomic_uint64_t safePoolFreeBlocks{};
+	std::atomic_uint64_t safePoolAllocs{};
+	std::atomic_uint64_t safePoolFailedAllocs{};
+	std::atomic_uint64_t safePoolDeallocs{};
+
+	void Log()
+	{
+		CryLogAlways("------------------------------- CryMemoryManager -------------------------------");
+
+		CryLogAlways("Calls:");
+		CryLogAlways("- CryMalloc: $5%" PRIu64 "$o + $5%" PRIu64 "$o",
+			mallocCalls.load(std::memory_order_relaxed),
+			crtMallocCalls.load(std::memory_order_relaxed));
+		CryLogAlways("- CryRealloc: $5%" PRIu64 "$o",
+			reallocCalls.load(std::memory_order_relaxed));
+		CryLogAlways("- CryFree: $5%" PRIu64 "$o + $5%" PRIu64 "$o",
+			freeCalls.load(std::memory_order_relaxed),
+			crtFreeCalls.load(std::memory_order_relaxed));
+		CryLogAlways("- CryGetMemSize: $5%" PRIu64 "$o",
+			sizeCalls.load(std::memory_order_relaxed));
+
+		CryLogAlways("SafePool:");
+		CryLogAlways("- Blocks: $5%" PRIu64 "$o ($5%" PRIu64 "$o free)",
+			safePoolBlocks.load(std::memory_order_relaxed),
+			safePoolFreeBlocks.load(std::memory_order_relaxed));
+		CryLogAlways("- Allocs: $5%" PRIu64 "$o ($5%" PRIu64 "$o failed)",
+			safePoolAllocs.load(std::memory_order_relaxed),
+			safePoolFailedAllocs.load(std::memory_order_relaxed));
+		CryLogAlways("- Deallocs: $5%" PRIu64 "$o",
+			safePoolDeallocs.load(std::memory_order_relaxed));
+
+		CryLogAlways("--------------------------------------------------------------------------------");
+	}
+};
+
+static Stats g_stats;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Debug allocator
@@ -339,109 +391,137 @@ static DebugAllocator& GetDebugAlloc()
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
-// Workaround for pointer truncation in 64-bit STLport allocator
+// Workaround for pointer truncation in 64-bit CryMemoryAllocator allocator
 ////////////////////////////////////////////////////////////////////////////////
 
 #ifdef BUILD_64BIT
 
-// TODO: fix and remove
-struct STLport_Allocator
+class SafePool
 {
+public:
 	static constexpr std::size_t BLOCK_SIZE = 0x80000;
-	static constexpr std::size_t BLOCK_COUNT = 2048;
+	static constexpr std::size_t BLOCK_COUNT = 2048;  // 0x80000 * 2048 = 1 GiB should be enough for anyone
 
 	static_assert(BLOCK_SIZE >= sizeof(void*));
 	static_assert(BLOCK_COUNT > 0);
 
-	void* freeList = nullptr;
-	void* freeListLast = nullptr;
-	std::mutex mutex;
-	std::array<void*, BLOCK_COUNT> blocks = {};
+private:
+	void* m_pool = nullptr;
+	std::size_t m_blockCount = 0;
+	void* m_freeList = nullptr;
+	void* m_freeListLast = nullptr;
+	std::mutex m_mutex;
 
-	STLport_Allocator()
+public:
+	SafePool()
 	{
-		for (std::size_t i = 0; i < BLOCK_COUNT; i++)
+		// use 0x80000000 .. 0xc0000000 for the pool to avoid interfering with DLL placement
+		void* hint = reinterpret_cast<void*>(0x80000000ULL);
+
+		void* pool = VirtualAlloc(hint, BLOCK_SIZE * BLOCK_COUNT, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+		if (!pool)
 		{
-			void* block = VirtualAlloc(nullptr, BLOCK_SIZE, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
-			if (!block)
+			return;
+		}
+
+		if (pool != hint)
+		{
+			VirtualFree(pool, 0, MEM_RELEASE);
+			return;
+		}
+
+		m_pool = pool;
+
+		std::size_t i = 0;
+		for (; i < BLOCK_COUNT; i++)
+		{
+			const std::uintptr_t address = reinterpret_cast<std::uintptr_t>(pool) + (i * BLOCK_SIZE);
+
+			// make sure the whole block is below 4 GB
+			if ((address + BLOCK_SIZE) > 0x100000000ULL)
 			{
-				Die("%s: VirtualAlloc failed with error code %u", __FUNCTION__, GetLastError());
+				break;
 			}
 
-			if (!this->freeList)
+			void* block = reinterpret_cast<void*>(address);
+
+			if (!m_freeList)
 			{
-				this->freeList = block;
-				this->freeListLast = block;
+				m_freeList = block;
+				m_freeListLast = block;
 			}
 			else
 			{
-				*static_cast<void**>(this->freeListLast) = block;
-				this->freeListLast = block;
-			}
-
-			blocks[i] = block;
-
-			if ((reinterpret_cast<std::uintptr_t>(block) + BLOCK_SIZE) > 0x100000000UL)
-			{
-				Die("%s: End of %p beyond 4 GiB boundary", __FUNCTION__, block);
+				*static_cast<void**>(m_freeListLast) = block;
+				m_freeListLast = block;
 			}
 		}
+
+		m_blockCount = i;
+		g_stats.safePoolBlocks.store(i, std::memory_order_relaxed);
+		g_stats.safePoolFreeBlocks.store(i, std::memory_order_relaxed);
 	}
 
 	void* Allocate()
 	{
-		std::lock_guard lock(this->mutex);
+		g_stats.safePoolAllocs.fetch_add(1, std::memory_order_relaxed);
 
-		void* block = this->freeList;
+		std::lock_guard lock(m_mutex);
 
-		if (this->freeList == this->freeListLast)
+		if (!m_freeList)
 		{
-			this->freeList = nullptr;
-			this->freeListLast = nullptr;
+			g_stats.safePoolFailedAllocs.fetch_add(1, std::memory_order_relaxed);
+			return nullptr;
+		}
+
+		void* block = m_freeList;
+
+		if (m_freeList == m_freeListLast)
+		{
+			m_freeList = nullptr;
+			m_freeListLast = nullptr;
 		}
 		else
 		{
-			this->freeList = *static_cast<void**>(this->freeList);
+			m_freeList = *static_cast<void**>(m_freeList);
 		}
 
-		if (!block)
-		{
-			Die("%s: Out of memory", __FUNCTION__);
-		}
+		g_stats.safePoolFreeBlocks.fetch_sub(1, std::memory_order_relaxed);
 
 		return block;
 	}
 
 	void Deallocate(void* block)
 	{
-		std::lock_guard lock(this->mutex);
+		g_stats.safePoolDeallocs.fetch_add(1, std::memory_order_relaxed);
 
-		if (!this->freeList)
+		std::lock_guard lock(m_mutex);
+
+		if (!m_freeList)
 		{
-			this->freeList = block;
-			this->freeListLast = block;
+			m_freeList = block;
+			m_freeListLast = block;
 		}
 		else
 		{
-			*static_cast<void**>(this->freeListLast) = block;
-			this->freeListLast = block;
+			*static_cast<void**>(m_freeListLast) = block;
+			m_freeListLast = block;
 		}
+
+		g_stats.safePoolFreeBlocks.fetch_add(1, std::memory_order_relaxed);
 	}
 
 	bool Contains(void* ptr) const
 	{
-		bool result = false;
+		const std::uintptr_t address = reinterpret_cast<std::uintptr_t>(ptr);
+		const std::uintptr_t poolBegin = reinterpret_cast<std::uintptr_t>(m_pool);
+		const std::uintptr_t poolEnd = poolBegin + (m_blockCount * BLOCK_SIZE);
 
-		for (void* block : this->blocks)
-		{
-			result |= (block == ptr);
-		}
-
-		return result;
+		return address >= poolBegin && address < poolEnd && !(address % BLOCK_SIZE);
 	}
 };
 
-STLport_Allocator* g_STLport_Allocator = nullptr;
+static SafePool* g_safePool;
 
 #endif
 
@@ -459,13 +539,12 @@ static void* CryMalloc_internal(std::size_t size, std::size_t& allocatedSize)
 	}
 
 #ifdef BUILD_64BIT
-	if (g_STLport_Allocator && size == STLport_Allocator::BLOCK_SIZE)
+	if (g_safePool && size == SafePool::BLOCK_SIZE)
 	{
-		void* ptr = g_STLport_Allocator->Allocate();
-
+		void* ptr = g_safePool->Allocate();
 		if (ptr)
 		{
-			TracyAllocN(ptr, size, "STLport");
+			TracyAllocN(ptr, size, "SafePool");
 			allocatedSize = size;
 		}
 
@@ -490,6 +569,8 @@ static void* CryMalloc_internal(std::size_t size, std::size_t& allocatedSize)
 
 CRYMALLOC_API void* CryMalloc(std::size_t size, std::size_t& allocatedSize)
 {
+	g_stats.mallocCalls.fetch_add(1, std::memory_order_relaxed);
+
 	if (gEnv)
 	{
 		FUNCTION_PROFILER(gEnv->pSystem, PROFILE_SYSTEM);
@@ -512,11 +593,11 @@ static void* CryRealloc_internal(void* oldPtr, std::size_t newSize, std::size_t&
 	std::size_t oldSize = 0;
 
 #ifdef BUILD_64BIT
-	const bool isSTLport = g_STLport_Allocator && g_STLport_Allocator->Contains(oldPtr);
+	const bool isSafePool = g_safePool && g_safePool->Contains(oldPtr);
 
-	if (isSTLport)
+	if (isSafePool)
 	{
-		oldSize = STLport_Allocator::BLOCK_SIZE;
+		oldSize = SafePool::BLOCK_SIZE;
 	}
 	else
 #endif
@@ -536,10 +617,10 @@ static void* CryRealloc_internal(void* oldPtr, std::size_t newSize, std::size_t&
 	}
 
 #ifdef BUILD_64BIT
-	if (isSTLport)
+	if (isSafePool)
 	{
-		TracyFreeN(oldPtr, "STLport");
-		g_STLport_Allocator->Deallocate(oldPtr);
+		TracyFreeN(oldPtr, "SafePool");
+		g_safePool->Deallocate(oldPtr);
 	}
 	else
 #endif
@@ -557,6 +638,8 @@ static void* CryRealloc_internal(void* oldPtr, std::size_t newSize, std::size_t&
 
 CRYMALLOC_API void* CryRealloc(void* oldPtr, std::size_t newSize, std::size_t& allocatedSize)
 {
+	g_stats.reallocCalls.fetch_add(1, std::memory_order_relaxed);
+
 	if (gEnv)
 	{
 		FUNCTION_PROFILER(gEnv->pSystem, PROFILE_SYSTEM);
@@ -577,9 +660,9 @@ static std::size_t CryGetMemSize_internal(void* ptr)
 	}
 
 #ifdef BUILD_64BIT
-	if (g_STLport_Allocator && g_STLport_Allocator->Contains(ptr))
+	if (g_safePool && g_safePool->Contains(ptr))
 	{
-		return STLport_Allocator::BLOCK_SIZE;
+		return SafePool::BLOCK_SIZE;
 	}
 #endif
 
@@ -592,6 +675,8 @@ static std::size_t CryGetMemSize_internal(void* ptr)
 
 CRYMALLOC_API std::size_t CryGetMemSize(void* ptr, std::size_t)
 {
+	g_stats.sizeCalls.fetch_add(1, std::memory_order_relaxed);
+
 	if (gEnv)
 	{
 		FUNCTION_PROFILER(gEnv->pSystem, PROFILE_SYSTEM);
@@ -612,12 +697,12 @@ static std::size_t CryFree_internal(void* ptr)
 	}
 
 #ifdef BUILD_64BIT
-	if (g_STLport_Allocator && g_STLport_Allocator->Contains(ptr))
+	if (g_safePool && g_safePool->Contains(ptr))
 	{
-		TracyFreeN(ptr, "STLport");
-		g_STLport_Allocator->Deallocate(ptr);
+		TracyFreeN(ptr, "SafePool");
+		g_safePool->Deallocate(ptr);
 
-		return STLport_Allocator::BLOCK_SIZE;
+		return SafePool::BLOCK_SIZE;
 	}
 #endif
 
@@ -636,6 +721,8 @@ static std::size_t CryFree_internal(void* ptr)
 
 CRYMALLOC_API std::size_t CryFree(void* ptr)
 {
+	g_stats.freeCalls.fetch_add(1, std::memory_order_relaxed);
+
 	if (gEnv)
 	{
 		FUNCTION_PROFILER(gEnv->pSystem, PROFILE_SYSTEM);
@@ -650,23 +737,46 @@ CRYMALLOC_API std::size_t CryFree(void* ptr)
 
 CRYMALLOC_API void* CrySystemCrtMalloc(std::size_t size)
 {
+	g_stats.crtMallocCalls.fetch_add(1, std::memory_order_relaxed);
+
 	std::size_t allocatedSize = 0;
-	return CryMalloc(size, allocatedSize);
+
+	if (gEnv)
+	{
+		FUNCTION_PROFILER(gEnv->pSystem, PROFILE_SYSTEM);
+
+		return CryMalloc_internal(size, allocatedSize);
+	}
+	else
+	{
+		return CryMalloc_internal(size, allocatedSize);
+	}
 }
 
 CRYMALLOC_API void CrySystemCrtFree(void* ptr)
 {
-	CryFree(ptr);
+	g_stats.crtFreeCalls.fetch_add(1, std::memory_order_relaxed);
+
+	if (gEnv)
+	{
+		FUNCTION_PROFILER(gEnv->pSystem, PROFILE_SYSTEM);
+
+		CryFree_internal(ptr);
+	}
+	else
+	{
+		CryFree_internal(ptr);
+	}
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 // CryMemoryManager
 ////////////////////////////////////////////////////////////////////////////////
 
-void CryMemoryManager::Init(void* pCrySystem)
+void CryMemoryManager::Init()
 {
 #ifdef BUILD_64BIT
-	g_STLport_Allocator = new STLport_Allocator;
+	g_safePool = new SafePool;
 #endif
 }
 
@@ -675,4 +785,9 @@ void CryMemoryManager::ProvideHeapInfo(std::FILE* file, void* address)
 #ifdef CRYMP_DEBUG_ALLOCATOR_ENABLED
 	GetDebugAlloc().ProvideHeapInfo(file, address);
 #endif
+}
+
+void CryMemoryManager::LogInfo()
+{
+	g_stats.Log();
 }

--- a/Code/CrySystem/CryMemoryManager.cpp
+++ b/Code/CrySystem/CryMemoryManager.cpp
@@ -17,7 +17,6 @@
 
 #include "CryCommon/CryCore/CryMalloc.h"
 #include "CryCommon/CrySystem/ISystem.h"
-#include "Library/WinAPI.h"
 
 #include "CryMemoryManager.h"
 
@@ -450,9 +449,14 @@ STLport_Allocator* g_STLport_Allocator = nullptr;
 // Hooked functions
 ////////////////////////////////////////////////////////////////////////////////
 
-static void* CryMalloc_hook_internal(std::size_t size, std::size_t& allocatedSize)
+static void* CryMalloc_internal(std::size_t size, std::size_t& allocatedSize)
 {
 	allocatedSize = 0;
+
+	if (!size)
+	{
+		return nullptr;
+	}
 
 #ifdef BUILD_64BIT
 	if (g_STLport_Allocator && size == STLport_Allocator::BLOCK_SIZE)
@@ -484,25 +488,25 @@ static void* CryMalloc_hook_internal(std::size_t size, std::size_t& allocatedSiz
 	return ptr;
 }
 
-static void* CryMalloc_hook(std::size_t size, std::size_t& allocatedSize)
+CRYMALLOC_API void* CryMalloc(std::size_t size, std::size_t& allocatedSize)
 {
 	if (gEnv)
 	{
 		FUNCTION_PROFILER(gEnv->pSystem, PROFILE_SYSTEM);
 
-		return CryMalloc_hook_internal(size, allocatedSize);
+		return CryMalloc_internal(size, allocatedSize);
 	}
 	else
 	{
-		return CryMalloc_hook_internal(size, allocatedSize);
+		return CryMalloc_internal(size, allocatedSize);
 	}
 }
 
-static void* CryRealloc_hook_internal(void* oldPtr, std::size_t newSize, std::size_t& allocatedSize)
+static void* CryRealloc_internal(void* oldPtr, std::size_t newSize, std::size_t& allocatedSize)
 {
 	if (!oldPtr)
 	{
-		return CryMalloc_hook_internal(newSize, allocatedSize);
+		return CryMalloc_internal(newSize, allocatedSize);
 	}
 
 	std::size_t oldSize = 0;
@@ -524,9 +528,12 @@ static void* CryRealloc_hook_internal(void* oldPtr, std::size_t newSize, std::si
 #endif
 	}
 
-	void* newPtr = CryMalloc_hook_internal(newSize, allocatedSize);
+	void* newPtr = CryMalloc_internal(newSize, allocatedSize);
 
-	std::memcpy(newPtr, oldPtr, (oldSize <= newSize) ? oldSize : newSize);
+	if (newPtr)
+	{
+		std::memcpy(newPtr, oldPtr, (oldSize <= newSize) ? oldSize : newSize);
+	}
 
 #ifdef BUILD_64BIT
 	if (isSTLport)
@@ -548,22 +555,27 @@ static void* CryRealloc_hook_internal(void* oldPtr, std::size_t newSize, std::si
 	return newPtr;
 }
 
-static void* CryRealloc_hook(void* oldPtr, std::size_t newSize, std::size_t& allocatedSize)
+CRYMALLOC_API void* CryRealloc(void* oldPtr, std::size_t newSize, std::size_t& allocatedSize)
 {
 	if (gEnv)
 	{
 		FUNCTION_PROFILER(gEnv->pSystem, PROFILE_SYSTEM);
 
-		return CryRealloc_hook_internal(oldPtr, newSize, allocatedSize);
+		return CryRealloc_internal(oldPtr, newSize, allocatedSize);
 	}
 	else
 	{
-		return CryRealloc_hook_internal(oldPtr, newSize, allocatedSize);
+		return CryRealloc_internal(oldPtr, newSize, allocatedSize);
 	}
 }
 
-static std::size_t CryGetMemSize_hook_internal(void* ptr)
+static std::size_t CryGetMemSize_internal(void* ptr)
 {
+	if (!ptr)
+	{
+		return 0;
+	}
+
 #ifdef BUILD_64BIT
 	if (g_STLport_Allocator && g_STLport_Allocator->Contains(ptr))
 	{
@@ -578,21 +590,21 @@ static std::size_t CryGetMemSize_hook_internal(void* ptr)
 #endif
 }
 
-static std::size_t CryGetMemSize_hook(void* ptr, std::size_t)
+CRYMALLOC_API std::size_t CryGetMemSize(void* ptr, std::size_t)
 {
 	if (gEnv)
 	{
 		FUNCTION_PROFILER(gEnv->pSystem, PROFILE_SYSTEM);
 
-		return CryGetMemSize_hook_internal(ptr);
+		return CryGetMemSize_internal(ptr);
 	}
 	else
 	{
-		return CryGetMemSize_hook_internal(ptr);
+		return CryGetMemSize_internal(ptr);
 	}
 }
 
-static std::size_t CryFree_hook_internal(void* ptr)
+static std::size_t CryFree_internal(void* ptr)
 {
 	if (!ptr)
 	{
@@ -622,29 +634,29 @@ static std::size_t CryFree_hook_internal(void* ptr)
 	return size;
 }
 
-static std::size_t CryFree_hook(void* ptr)
+CRYMALLOC_API std::size_t CryFree(void* ptr)
 {
 	if (gEnv)
 	{
 		FUNCTION_PROFILER(gEnv->pSystem, PROFILE_SYSTEM);
 
-		return CryFree_hook_internal(ptr);
+		return CryFree_internal(ptr);
 	}
 	else
 	{
-		return CryFree_hook_internal(ptr);
+		return CryFree_internal(ptr);
 	}
 }
 
-static void* CrySystemCrtMalloc_hook(std::size_t size)
+CRYMALLOC_API void* CrySystemCrtMalloc(std::size_t size)
 {
 	std::size_t allocatedSize = 0;
-	return CryMalloc_hook(size, allocatedSize);
+	return CryMalloc(size, allocatedSize);
 }
 
-static void CrySystemCrtFree_hook(void* ptr)
+CRYMALLOC_API void CrySystemCrtFree(void* ptr)
 {
-	CryFree_hook(ptr);
+	CryFree(ptr);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -656,13 +668,6 @@ void CryMemoryManager::Init(void* pCrySystem)
 #ifdef BUILD_64BIT
 	g_STLport_Allocator = new STLport_Allocator;
 #endif
-
-	WinAPI::HookWithJump(WinAPI::DLL::GetSymbol(pCrySystem, "CryMalloc"), &CryMalloc_hook);
-	WinAPI::HookWithJump(WinAPI::DLL::GetSymbol(pCrySystem, "CryRealloc"), &CryRealloc_hook);
-	WinAPI::HookWithJump(WinAPI::DLL::GetSymbol(pCrySystem, "CryGetMemSize"), &CryGetMemSize_hook);
-	WinAPI::HookWithJump(WinAPI::DLL::GetSymbol(pCrySystem, "CryFree"), &CryFree_hook);
-	WinAPI::HookWithJump(WinAPI::DLL::GetSymbol(pCrySystem, "CrySystemCrtMalloc"), &CrySystemCrtMalloc_hook);
-	WinAPI::HookWithJump(WinAPI::DLL::GetSymbol(pCrySystem, "CrySystemCrtFree"), &CrySystemCrtFree_hook);
 }
 
 void CryMemoryManager::ProvideHeapInfo(std::FILE* file, void* address)
@@ -670,25 +675,4 @@ void CryMemoryManager::ProvideHeapInfo(std::FILE* file, void* address)
 #ifdef CRYMP_DEBUG_ALLOCATOR_ENABLED
 	GetDebugAlloc().ProvideHeapInfo(file, address);
 #endif
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// CryCommon/CryCore/CryMalloc.h
-////////////////////////////////////////////////////////////////////////////////
-
-void* CryMalloc(std::size_t size)
-{
-	std::size_t allocatedSize = 0;
-	return CryMalloc_hook(size, allocatedSize);
-}
-
-void* CryRealloc(void* oldPtr, std::size_t newSize)
-{
-	std::size_t allocatedSize = 0;
-	return CryRealloc_hook(oldPtr, newSize, allocatedSize);
-}
-
-void CryFree(void* ptr)
-{
-	CryFree_hook(ptr);
 }

--- a/Code/CrySystem/CryMemoryManager.h
+++ b/Code/CrySystem/CryMemoryManager.h
@@ -4,7 +4,9 @@
 
 namespace CryMemoryManager
 {
-	void Init(void* pCrySystem);
+	void Init();
 
 	void ProvideHeapInfo(std::FILE* file, void* address);
+
+	void LogInfo();
 }

--- a/Code/Launcher/Launcher.cpp
+++ b/Code/Launcher/Launcher.cpp
@@ -1272,6 +1272,7 @@ void Launcher::PatchEngine()
 		MemoryPatch::CryAction::AllowDX9ImmersiveMultiplayer(g_pCryAction);
 		MemoryPatch::CryAction::AllowMultiplayerRegisterWithAI(g_pCryAction);
 		MemoryPatch::CryAction::DisableBreakLog(g_pCryAction);
+		MemoryPatch::CryAction::DisableGameplayStats(g_pCryAction);
 		MemoryPatch::CryAction::DisableTimeOfDayLengthLowerLimit(g_pCryAction);
 		MemoryPatch::CryAction::HookCryWarning(g_pCryAction, &OnCryWarning);
 		MemoryPatch::CryAction::HookGameWarning(g_pCryAction, &OnGameWarning);

--- a/Code/Launcher/Launcher.cpp
+++ b/Code/Launcher/Launcher.cpp
@@ -103,6 +103,31 @@ static void OnD3D10Info(MemoryPatch::CryRenderD3D10::AdapterInfo* info)
 	LogBytes("D3D10 Adapter: Shared system memory = ", info->shared_system_memory);
 }
 
+static bool OnD3D10Init(MemoryPatch::CryRenderD3D10::SystemAPI* api)
+{
+	void* d3d10 = WinAPI::DLL::Load("d3d10.dll");
+	if (!d3d10)
+	{
+		WinAPI::ErrorBox(StringTools::SysErrorFormat("Failed to load the D3D10 DLL!").what());
+		return false;
+	}
+
+	api->pD3D10 = d3d10;
+	api->pD3D10CreateDevice = WinAPI::DLL::GetSymbol(d3d10, "D3D10CreateDevice");
+
+	void* dxgi = WinAPI::DLL::Load("dxgi.dll");
+	if (!dxgi)
+	{
+		WinAPI::ErrorBox(StringTools::SysErrorFormat("Failed to load the DXGI DLL!").what());
+		return false;
+	}
+
+	api->pDXGI = dxgi;
+	api->pCreateDXGIFactory = WinAPI::DLL::GetSymbol(dxgi, "CreateDXGIFactory");
+
+	return true;
+}
+
 static void OnCryWarning(int, int, const char* format, ...)
 {
 	// the original buffer size
@@ -1356,6 +1381,7 @@ void Launcher::PatchEngine()
 		MemoryPatch::CryRenderD3D10::FixUseAfterFreeInShaderParser(g_pCryRenderD3D10);
 		MemoryPatch::CryRenderD3D10::HookWindowNameD3D10(g_pCryRenderD3D10, GAME_WINDOW_NAME);
 		MemoryPatch::CryRenderD3D10::HookAdapterInfo(g_pCryRenderD3D10, &OnD3D10Info);
+		MemoryPatch::CryRenderD3D10::HookInitAPI(g_pCryRenderD3D10, &OnD3D10Init);
 	}
 
 	if (g_pCryRenderNULL)

--- a/Code/Launcher/Launcher.cpp
+++ b/Code/Launcher/Launcher.cpp
@@ -1172,8 +1172,6 @@ void Launcher::LoadEngine()
 		}
 	}
 
-	CryMemoryManager::Init(g_pCrySystem);
-
 	g_pCryAction = WinAPI::DLL::Load("CryAction.dll");
 	if (!g_pCryAction)
 	{
@@ -1562,6 +1560,10 @@ void Launcher::OnEarlyEngineInit(ISystem* pSystem)
 	gEnv->pConsole->AddCommand("LocalizationManagerInfo", [](IConsoleCmdArgs* args) {
 		LocalizationManager::GetInstance().LogInfo();
 	});
+
+	gEnv->pConsole->AddCommand("CryMemoryManagerInfo", [](IConsoleCmdArgs* args) {
+		CryMemoryManager::LogInfo();
+	});
 }
 
 struct DummySystemCallback : public ISystemUserCallback
@@ -1606,6 +1608,8 @@ void Launcher::Run()
 
 	this->InitWorkingDirectory();
 	this->SetCmdLine();
+
+	CryMemoryManager::Init();
 
 	this->LoadEngine();
 	this->PatchEngine();

--- a/Code/Launcher/MemoryPatch.cpp
+++ b/Code/Launcher/MemoryPatch.cpp
@@ -732,6 +732,50 @@ void MemoryPatch::CryRenderD3D10::HookAdapterInfo(void* pCryRenderD3D10, void (*
 #endif
 }
 
+/**
+ * Hooks D3D10 API initialization.
+ *
+ * CryRenderD3D10 loads d3d10.dll and dxgi.dll with absolute paths (GetSystemDirectoryW) for some reason.
+ * This patch is used to load these DLLs normally, so placing them next to CryRenderD3D10.dll works as expected.
+ */
+void MemoryPatch::CryRenderD3D10::HookInitAPI(void* pCryRenderD3D10, bool (*handler)(SystemAPI* api))
+{
+#ifdef BUILD_64BIT
+	unsigned char code[] = {
+		0x48, 0x8D, 0x0D, 0xF3, 0xFF, 0xFF, 0xFF,                    // lea rcx, qword ptr ds:[rip-0xD]
+		0x03, 0x0D, 0xE8, 0xFF, 0xFF, 0xFF,                          // add ecx, dword ptr ds:[rip-0x18]
+		0x48, 0xB8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // mov rax, 0x0
+		0xFF, 0xD0,                                                  // call rax
+		0x48, 0x81, 0xC4, 0x38, 0x02, 0x00, 0x00,                    // add rsp, 0x238
+		0xC3,                                                        // ret
+		0x90,                                                        // nop
+		0x90,                                                        // nop
+	};
+
+	std::memcpy(&code[15], &handler, 8);
+#else
+	unsigned char code[] = {
+		0xE8, 0x12, 0x00, 0x00, 0x00,        // call get_pc -----------------------+
+		0x8B, 0x40, 0xF0,                    // mov eax, dword ptr ds:[eax-0x10]   |
+		0x50,                                // push eax                           |
+		0xB8, 0x00, 0x00, 0x00, 0x00,        // mov eax, 0x0                       |
+		0xFF, 0xD0,                          // call eax                           |
+		0x81, 0xC4, 0x10, 0x02, 0x00, 0x00,  // add esp, 0x210                     |
+		0xC3,                                // ret                                |
+		0x8B, 0x04, 0x24,                    // mov eax, dword ptr ss:[esp]  <-----+
+		0xC3,                                // ret
+	};
+
+	std::memcpy(&code[10], &handler, 4);
+#endif
+
+#ifdef BUILD_64BIT
+	FillMem(pCryRenderD3D10, 0x1C99D3, &code, sizeof(code));
+#else
+	FillMem(pCryRenderD3D10, 0x171080, &code, sizeof(code));
+#endif
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // CryRenderNULL
 ////////////////////////////////////////////////////////////////////////////////

--- a/Code/Launcher/MemoryPatch.cpp
+++ b/Code/Launcher/MemoryPatch.cpp
@@ -97,6 +97,28 @@ void MemoryPatch::CryAction::DisableBreakLog(void* pCryAction)
 }
 
 /**
+ * Disables automatic creation of "gameplaystatsXXX.txt" files.
+ *
+ * The "dump_stats" console command can still be used to create these files manually.
+ */
+void MemoryPatch::CryAction::DisableGameplayStats(void* pCryAction)
+{
+#ifdef BUILD_64BIT
+	const unsigned char code[] = {
+		0xC3,  // ret
+		0x90,  // nop
+		0x90,  // nop
+		0x90,  // nop
+		0x90   // nop
+	};
+
+	FillMem(pCryAction, 0x2FA976, code, sizeof(code));
+#else
+	FillNop(pCryAction, 0x20605D, 0x7);
+#endif
+}
+
+/**
  * Disables the lower limit of ToD length.
  */
 void MemoryPatch::CryAction::DisableTimeOfDayLengthLowerLimit(void* pCryAction)

--- a/Code/Launcher/MemoryPatch.h
+++ b/Code/Launcher/MemoryPatch.h
@@ -80,10 +80,28 @@ namespace MemoryPatch
 			// ...
 		};
 
+		struct SystemAPI
+		{
+			void* pDXGI;
+			void* pCreateDXGIFactory;
+			void* pD3D10;
+			void* pD3D10CreateStateBlock;              // unused
+			void* pD3D10CreateDevice;
+			void* pD3D10StateBlockMaskUnion;           // unused
+			void* pD3D10StateBlockMaskIntersect;       // unused
+			void* pD3D10StateBlockMaskDifference;      // unused
+			void* pD3D10StateBlockMaskEnableCapture;   // unused
+			void* pD3D10StateBlockMaskDisableCapture;  // unused
+			void* pD3D10StateBlockMaskEnableAll;       // unused
+			void* pD3D10StateBlockMaskDisableAll;      // unused
+			void* pD3D10StateBlockMaskGetSetting;      // unused
+		};
+
 		void FixLowRefreshRateBug(void* pCryRenderD3D10);
 		void FixUseAfterFreeInShaderParser(void* pCryRenderD3D10);
 		void HookWindowNameD3D10(void* pCryRenderD3D10, const char* name);
 		void HookAdapterInfo(void* pCryRenderD3D10, void (*handler)(AdapterInfo* info));
+		void HookInitAPI(void* pCryRenderD3D10, bool (*handler)(SystemAPI* api));
 	}
 
 	namespace CryRenderNULL

--- a/Code/Launcher/MemoryPatch.h
+++ b/Code/Launcher/MemoryPatch.h
@@ -18,6 +18,7 @@ namespace MemoryPatch
 		void AllowDX9ImmersiveMultiplayer(void* pCryAction);
 		void AllowMultiplayerRegisterWithAI(void* pCryAction);
 		void DisableBreakLog(void* pCryAction);
+		void DisableGameplayStats(void* pCryAction);
 		void DisableTimeOfDayLengthLowerLimit(void* pCryAction);
 		void HookGameWarning(void* pCryAction, void (*handler)(const char* format, ...));
 		void HookCryWarning(void* pCryAction, void (*handler)(int, int, const char* format, ...));

--- a/Code/Library/CrashLogger.cpp
+++ b/Code/Library/CrashLogger.cpp
@@ -1,3 +1,4 @@
+#include <csignal>
 #include <cstdlib>
 #include <cstring>
 
@@ -15,6 +16,7 @@
 #define ADDR_FMT "%08X"
 #endif
 
+#define CRASH_LOGGER_ABORT 0xE0C1C100
 #define CRASH_LOGGER_PURE_CALL 0xE0C1C101
 #define CRASH_LOGGER_INVALID_PARAM 0xE0C1C102
 #define CRASH_LOGGER_ENGINE_ERROR 0xE0C1C103
@@ -70,6 +72,7 @@ static const char* ExceptionCodeToName(unsigned int code)
 		case EXCEPTION_SINGLE_STEP:              return "Single step";
 		case EXCEPTION_STACK_OVERFLOW:           return "Stack overflow";
 		case 0xE06D7363:                         return "C++ exception";
+		case CRASH_LOGGER_ABORT:                 return "Abnormal program termination";
 		case CRASH_LOGGER_PURE_CALL:             return "Pure virtual function call";
 		case CRASH_LOGGER_INVALID_PARAM:         return "Invalid parameter detected by CRT";
 		case CRASH_LOGGER_ENGINE_ERROR:          return "Engine error";
@@ -460,6 +463,12 @@ static LONG __stdcall CrashHandler(EXCEPTION_POINTERS* exception)
 	return EXCEPTION_CONTINUE_SEARCH;
 }
 
+static void AbortHandler(int)
+{
+	RaiseException(CRASH_LOGGER_ABORT, EXCEPTION_NONCONTINUABLE, 0, NULL);
+	ExitProcess(1);
+}
+
 static void PureCallHandler()
 {
 	RaiseException(CRASH_LOGGER_PURE_CALL, EXCEPTION_NONCONTINUABLE, 0, NULL);
@@ -492,12 +501,29 @@ void CrashLogger::Enable(LogFileProvider logFileProvider, HeapInfoProvider heapI
 
 	SetUnhandledExceptionFilter(&CrashHandler);
 
+	std::signal(SIGABRT, &AbortHandler);
+	_set_abort_behavior(0, _WRITE_ABORT_MSG);  // suppress abort message (console) and dialog (GUI)
+
 	_set_purecall_handler(&PureCallHandler);
 	_set_invalid_parameter_handler(&InvalidParameterHandler);
 
 	HMODULE msvcr80 = LoadLibraryA("msvcr80.dll");
 	if (msvcr80)
 	{
+		void* vs2005_signal = GetProcAddress(msvcr80, "signal");
+		if (vs2005_signal)
+		{
+			static_cast<void(*(*)(int, void(*)(int)))(int)>
+				(vs2005_signal)(SIGABRT, &AbortHandler);
+		}
+
+		void* vs2005_set_abort_behavior = GetProcAddress(msvcr80, "_set_abort_behavior");
+		if (vs2005_set_abort_behavior)
+		{
+			static_cast<unsigned int(*)(unsigned int, unsigned int)>
+				(vs2005_set_abort_behavior)(0, _WRITE_ABORT_MSG);
+		}
+
 		void* vs2005_set_purecall_handler = GetProcAddress(msvcr80, "_set_purecall_handler");
 		if (vs2005_set_purecall_handler)
 		{

--- a/Code/Library/StlportVector.h
+++ b/Code/Library/StlportVector.h
@@ -5,10 +5,9 @@
 #include <cstdlib>
 #include <memory>
 
-extern std::uintptr_t CRYACTION_BASE;
+#include "CryCommon/CryCore/CryMalloc.h"
 
-void* CryMalloc(std::size_t size);
-void CryFree(void* ptr);
+extern std::uintptr_t CRYACTION_BASE;
 
 template<class T>
 class NodeAlloc_CryAction
@@ -28,7 +27,16 @@ public:
 		// _M_allocate instead of allocate
 		AllocFunc alloc = reinterpret_cast<AllocFunc>(CRYACTION_BASE + 0x73A0);
 
-		void *p = (bytes > 0x200) ? CryMalloc(bytes) : alloc(bytes);
+		void *p = nullptr;
+		if (bytes > 0x200)
+		{
+			std::size_t allocatedSize = 0;
+			p = CryMalloc(bytes, allocatedSize);
+		}
+		else
+		{
+			p = alloc(bytes);
+		}
 #endif
 
 		if (!p)
@@ -53,7 +61,14 @@ public:
 		// _M_deallocate instead of deallocate
 		DeallocFunc dealloc = reinterpret_cast<DeallocFunc>(CRYACTION_BASE + 0x6C30);
 
-		(bytes > 0x200) ? CryFree(p) : dealloc(p, bytes);
+		if (bytes > 0x200)
+		{
+			CryFree(p);
+		}
+		else
+		{
+			dealloc(p, bytes);
+		}
 #endif
 	}
 };


### PR DESCRIPTION
### Improved fix for 64-bit pointer truncation in CryMemoryAllocator

The main change here is clean hooking of CryMalloc functions by simply exporting them from the EXE. This works because the CryMemoryManager helper in each engine DLL searches for the functions in the EXE first and then falls back to `CrySystem.dll`. For this reason, our internal CryMalloc functions need to have the same signature as the original ones. Most of the changes are due to this.

The `STLport_Allocator` class is replaced with the improved `SafePool` class from c1-launcher. It allocates the pool as a single large chunk of memory. This allows the `Contains` function to be `O(1)` instead of `O(n)`. The pool location is chosen to avoid unnecessary relocation of engine DLLs. See https://github.com/ccomrade/c1-launcher/pull/84.

Also, `CryMemoryManagerInfo` console command is added to show the statistics.

### Abort handler in crash logger

The crash logger is now able to catch `abort()` calls.

### Additional engine patches

The following patches from c1-launcher are added:

- `CryAction::DisableGameplayStats`: Prevent CryMP-Server from automatically creating unnecessary `Game/gameplaystatsXXX.txt` files.
- `CryRenderD3D10::HookInitAPI`: Support loading custom D3D10 DLLs from Bin32 and Bin64 directories. This allows using DXVK on Windows.