### PR TITLE
Add server pak support to CryMP-Server

### DIFF
--- a/SSMs/SafeWriting/CryMP-Server/SafeWriting/SafeWritingMain.lua
+++ b/SSMs/SafeWriting/CryMP-Server/SafeWriting/SafeWritingMain.lua
@@ -176,6 +176,10 @@ function SafeWriting:OnTimerTick()
 			if mapver ~= 0 then
 				map = map .. "|" .. mapver
 			end
+			pakdl = ""
+			if se.ServerPakUrl then
+				pakdl = se.ServerPakUrl
+			end
 			local desc = se.ServerDescription or ""
 			local mappic = se.MapPictures and (se.MapPictures[GetMapName()] or "") or ""
 			local local_ip = se.LocalIP and se.LocalIP or (CPPAPI and CPPAPI.GetLocalIP() or "localhost")
@@ -184,8 +188,8 @@ function SafeWriting:OnTimerTick()
 			if not TOLD_EXISTENTION and (not MASTER_COOKIE) then
 				local rules = GetGameRules()
 				local page = urlfmt(
-					"/api/reg.php?port=%d&maxpl=%d&numpl=%d&name=%s&pass=%s&map=%s&timel=%d&mapdl=%s&ver=%d&ranked=%d&desc=%s&mappic=%s&local=%s&pak=%s&rules=%s&teams=%d",
-					port, maxpl, numpl, svn, svp, map, g_gameRules.game:GetRemainingGameTime(), mapdl, ver, rnk, desc,
+					"/api/reg.php?port=%d&maxpl=%d&numpl=%d&name=%s&pass=%s&map=%s&timel=%d&mapdl=%s&pak=%s&ver=%d&ranked=%d&desc=%s&mappic=%s&local=%s&pak=%s&rules=%s&teams=%d",
+					port, maxpl, numpl, svn, svp, map, g_gameRules.game:GetRemainingGameTime(), mapdl, pakdl, ver, rnk, desc,
 					mappic, local_ip, pak, rules.name, rules.teams)
 				AsyncConnectHTTP(se.MasterHost or "crymp.org", page, se.ForceGET and "GET" or "POST", 443, true, 15,
 					function(c)
@@ -226,8 +230,8 @@ function SafeWriting:OnTimerTick()
 				map = map or "unknown"
 				local rules = GetGameRules()
 				local page = urlfmt(
-					"/api/up.php?port=%d&numpl=%d&name=%s&pass=%s&cookie=%s&map=%s&timel=%d&mapdl=%s&ver=%d&ranked=%d&players=%s&desc=%s&mappic=%s&local=%s&pak=%s&rules=%s&teams=%d",
-					port, numpl, svn, svp, MASTER_COOKIE, map, g_gameRules.game:GetRemainingGameTime(), mapdl, ver, rnk,
+					"/api/up.php?port=%d&numpl=%d&name=%s&pass=%s&cookie=%s&map=%s&timel=%d&mapdl=%s&pak=%s&ver=%d&ranked=%d&players=%s&desc=%s&mappic=%s&local=%s&pak=%s&rules=%s&teams=%d",
+					port, numpl, svn, svp, MASTER_COOKIE, map, g_gameRules.game:GetRemainingGameTime(), mapdl, pakdl, ver, rnk,
 					plstring, desc, mappic, local_ip, pak, rules.name, rules.teams)
 				AsyncConnectHTTP(se.MasterHost or "crymp.org", page, se.ForceGET and "GET" or "POST", 443, true, 15,
 					function(c)

--- a/SSMs/SafeWriting/CryMP-Server/SafeWriting/SafeWritingMain.lua
+++ b/SSMs/SafeWriting/CryMP-Server/SafeWriting/SafeWritingMain.lua
@@ -176,10 +176,6 @@ function SafeWriting:OnTimerTick()
 			if mapver ~= 0 then
 				map = map .. "|" .. mapver
 			end
-			pakdl = ""
-			if se.ServerPakUrl then
-				pakdl = se.ServerPakUrl
-			end
 			local desc = se.ServerDescription or ""
 			local mappic = se.MapPictures and (se.MapPictures[GetMapName()] or "") or ""
 			local local_ip = se.LocalIP and se.LocalIP or (CPPAPI and CPPAPI.GetLocalIP() or "localhost")
@@ -188,8 +184,8 @@ function SafeWriting:OnTimerTick()
 			if not TOLD_EXISTENTION and (not MASTER_COOKIE) then
 				local rules = GetGameRules()
 				local page = urlfmt(
-					"/api/reg.php?port=%d&maxpl=%d&numpl=%d&name=%s&pass=%s&map=%s&timel=%d&mapdl=%s&pak=%s&ver=%d&ranked=%d&desc=%s&mappic=%s&local=%s&pak=%s&rules=%s&teams=%d",
-					port, maxpl, numpl, svn, svp, map, g_gameRules.game:GetRemainingGameTime(), mapdl, pakdl, ver, rnk, desc,
+					"/api/reg.php?port=%d&maxpl=%d&numpl=%d&name=%s&pass=%s&map=%s&timel=%d&mapdl=%s&ver=%d&ranked=%d&desc=%s&mappic=%s&local=%s&pak=%s&rules=%s&teams=%d",
+					port, maxpl, numpl, svn, svp, map, g_gameRules.game:GetRemainingGameTime(), mapdl, ver, rnk, desc,
 					mappic, local_ip, pak, rules.name, rules.teams)
 				AsyncConnectHTTP(se.MasterHost or "crymp.org", page, se.ForceGET and "GET" or "POST", 443, true, 15,
 					function(c)
@@ -230,8 +226,8 @@ function SafeWriting:OnTimerTick()
 				map = map or "unknown"
 				local rules = GetGameRules()
 				local page = urlfmt(
-					"/api/up.php?port=%d&numpl=%d&name=%s&pass=%s&cookie=%s&map=%s&timel=%d&mapdl=%s&pak=%s&ver=%d&ranked=%d&players=%s&desc=%s&mappic=%s&local=%s&pak=%s&rules=%s&teams=%d",
-					port, numpl, svn, svp, MASTER_COOKIE, map, g_gameRules.game:GetRemainingGameTime(), mapdl, pakdl, ver, rnk,
+					"/api/up.php?port=%d&numpl=%d&name=%s&pass=%s&cookie=%s&map=%s&timel=%d&mapdl=%s&ver=%d&ranked=%d&players=%s&desc=%s&mappic=%s&local=%s&pak=%s&rules=%s&teams=%d",
+					port, numpl, svn, svp, MASTER_COOKIE, map, g_gameRules.game:GetRemainingGameTime(), mapdl, ver, rnk,
 					plstring, desc, mappic, local_ip, pak, rules.name, rules.teams)
 				AsyncConnectHTTP(se.MasterHost or "crymp.org", page, se.ForceGET and "GET" or "POST", 443, true, 15,
 					function(c)

--- a/SSMs/SafeWriting/CryMP-Server/Settings/Settings.lua
+++ b/SSMs/SafeWriting/CryMP-Server/Settings/Settings.lua
@@ -20,8 +20,8 @@ SafeWriting.Settings={
 	APIKey=nil;	--leave this empty unless you are a trusted server
 	
 	--if set, clients will download and load the pak file when connecting to this server
-	--for example: ServerPakUrl="https://example.com/example.pak";
-	ServerPakUrl=nil;
+	--for example: PAK="https://example.com/example.pak";
+	PAK=nil;
 
 	OptimizeSpeed=false;	--makes server do less output (recommended for non-stop servers)
 	HomeCountry="unknown";	--set it to anything, for example: sk,cz,pl,ua,at,ru,de,uk,...

--- a/SSMs/SafeWriting/CryMP-Server/Settings/Settings.lua
+++ b/SSMs/SafeWriting/CryMP-Server/Settings/Settings.lua
@@ -19,6 +19,10 @@ SafeWriting.Settings={
 	ServerDescription="A new CryMP server";	--description for your server
 	APIKey=nil;	--leave this empty unless you are a trusted server
 	
+	--if set, clients will download and load the pak file when connecting to this server
+	--for example: ServerPakUrl="https://example.com/example.pak";
+	ServerPakUrl=nil;
+
 	OptimizeSpeed=false;	--makes server do less output (recommended for non-stop servers)
 	HomeCountry="unknown";	--set it to anything, for example: sk,cz,pl,ua,at,ru,de,uk,...
 	EnableSafeWritingExe=true;	--enables using SSMSafeWriting.exe for mod


### PR DESCRIPTION
An optional server pak download link can now be set using `SafeWriting.Settings.ServerPakUrl`.