### PR TITLE
Add -nocrashlogger

### DIFF
--- a/Code/CrySystem/CryMemoryManager.cpp
+++ b/Code/CrySystem/CryMemoryManager.cpp
@@ -567,6 +567,11 @@ static void* CryMalloc_internal(std::size_t size, std::size_t& allocatedSize)
 	return ptr;
 }
 
+#ifdef CRYMALLOC_API
+#undef CRYMALLOC_API
+#define CRYMALLOC_API extern "C"
+#endif
+
 CRYMALLOC_API void* CryMalloc(std::size_t size, std::size_t& allocatedSize)
 {
 	g_stats.mallocCalls.fetch_add(1, std::memory_order_relaxed);

--- a/Code/Launcher/Launcher.cpp
+++ b/Code/Launcher/Launcher.cpp
@@ -1313,7 +1313,9 @@ void Launcher::PatchEngine()
 		MemoryPatch::CrySystem::FixCPUInfoOverflow(g_pCrySystem);
 		MemoryPatch::CrySystem::FixFlashAllocatorUnderflow(g_pCrySystem);
 		MemoryPatch::CrySystem::HookCPUDetect(g_pCrySystem, &CPUInfo::Detect);
-		MemoryPatch::CrySystem::HookError(g_pCrySystem, &CrashLogger::OnEngineError);
+		if (!WinAPI::CmdLine::HasArg("-nocrashlogger")) {
+			MemoryPatch::CrySystem::HookError(g_pCrySystem, &CrashLogger::OnEngineError);
+		}
 		//MemoryPatch::CrySystem::MakeDX9Default(g_pCrySystem);
 		MemoryPatch::CrySystem::RemoveSecuROM(g_pCrySystem);
 		MemoryPatch::CrySystem::UnhandledExceptions(g_pCrySystem);
@@ -1509,7 +1511,9 @@ void Launcher::OnEarlyEngineInit(ISystem* pSystem)
 	const char* banner = "CryMP Server " CRYMP_VERSION_STRING " " CRYMP_BITS " " CRYMP_BUILD_TYPE;
 #endif
 
-	CrashLogger::Enable(&ProvideLogFile, &CryMemoryManager::ProvideHeapInfo, banner);
+	if (!WinAPI::CmdLine::HasArg("-nocrashlogger")) {
+		CrashLogger::Enable(&ProvideLogFile, &CryMemoryManager::ProvideHeapInfo, banner);
+	}
 
 	logger.LogAlways("Log begins at %s", Logger::FormatPrefix("%F %T%z").c_str());
 

--- a/Code/Launcher/Main.cpp
+++ b/Code/Launcher/Main.cpp
@@ -26,6 +26,7 @@ int main()
 int __stdcall WinMain(void*, void*, char*, int)
 #endif
 {
+#ifdef CLIENT_LAUNCHER
 	try
 	{
 		Launcher().Run();
@@ -41,4 +42,7 @@ int __stdcall WinMain(void*, void*, char*, int)
 	}
 
 	return 0;
+#else
+	Launcher().Run();
+#endif
 }


### PR DESCRIPTION
Add an option to disable crashlogger. 
This is useful when using --minidump option with Wine, so the program crashes properly and generates a promper dump file.

Also remove MessageBox error handler for server, since this is not very useful when server runs in a CLI :D