### PR TITLE
Move ads authority from master to individual servers

### DIFF
--- a/Code/CryMP/Client/Advertising.cpp
+++ b/Code/CryMP/Client/Advertising.cpp
@@ -33,6 +33,8 @@
 #define AD_CYCLE_ERROR 2
 
 #define ADVERTISING_SERVER_TOKEN 3000
+#define ADVERTISING_SERVER_RESPONSE 3001
+
 
 #ifndef ADS_ENABLED
 #define ADS_ENABLED true
@@ -41,6 +43,8 @@
 #ifndef ADS_SERVER
 #define ADS_SERVER "https://crymp.org/adserve/api/v1/public/ads"
 #endif
+
+// #define ADS_REMOTE
 
 struct SAdCue {
 	Vec3 pos;
@@ -87,13 +91,14 @@ void CAdManager::Update(float delta) {
 			return;
 		}
 
-
+#ifdef REMOTE_ADS
 		if (g_pGameCVars->ads == 0) {
 			const auto profile{ gClient->GetScriptBind_CPPAPI()->GetProfile("real") };
 			if (profile && profile->playedTime > (100.0f * 3600.0f)) {
 				return;
 			}
 		}
+#endif
 
 		CycleAds(delta);
 	}
@@ -379,12 +384,13 @@ IMaterial* CAdManager::FindMaterial(const SAdGroup& group, const SAdVersion& ver
 }
 
 void CAdManager::FetchAds() {
+	CSynchedStorage* pSSS = g_pGame->GetSynchedStorage();
+#ifdef REMOTE_ADS
 	auto collected = std::move(m_collectedRecords);
 	std::string collectedSerialized;
 	try {
 		std::string serverToken;
 
-		CSynchedStorage* pSSS = g_pGame->GetSynchedStorage();
 		if (pSSS) {
 			string csServerToken;
 			if (pSSS->GetGlobalValue(ADVERTISING_SERVER_TOKEN, csServerToken)) {
@@ -429,33 +435,7 @@ void CAdManager::FetchAds() {
 		.headers = {{"Content-type", "application/json"}},
 		.callback = [this](const HTTPClientResult& result) -> void {
 			if (result.code == 200) {
-				try {
-					m_upcomingAds.clear();
-					auto ads{ nlohmann::json::parse(result.response) };
-					auto& groups = ads["groups"];
-					for (size_t i = 0; i < groups.size(); i++) {
-						std::vector<SAdVersion> versions;
-						auto& jsonVersions = groups[i]["versions"];
-						for (size_t j = 0; j < jsonVersions.size(); j++) {
-							versions.emplace_back(SAdVersion{
-								.id = jsonVersions[j]["id"].get<std::string>(),
-								.path = jsonVersions[j]["path"].get<std::string>(),
-								.aspectRatio = jsonVersions[j]["aspectRatio"].get<float>(),
-							});
-						}
-						m_upcomingAds.emplace_back(SAdGroup{
-							.id = groups[i]["id"].get<std::string>(),
-							.viewId = groups[i]["viewId"].get<std::string>(),
-							.versions = std::move(versions)
-						});
-					}
-					m_upcomingPakUrl = ads["resources"].get<std::string>();
-					m_state = EAdState::eAS_FetchedAds;
-				} catch (nlohmann::json::exception& ex) {
-				  CryLogAlways("$4Failed to parse ads response: %s", ex.what());
-				  m_cycles[AD_CYCLE_ERROR] = m_time;
-				  m_state = EAdState::eAS_Error;
-				}
+				LoadAds(result.response);
 			} else {
 				 CryLogWarning("$4Failed to retrieve ads: %d", result.code);
 				 m_cycles[AD_CYCLE_ERROR] = m_time;
@@ -463,6 +443,55 @@ void CAdManager::FetchAds() {
 			}
 		}
 	});
+#else
+	std::string serverResponse;
+	m_collectedRecords.clear();
+
+	if (pSSS) {
+		string csServerResponse;
+		if (pSSS->GetGlobalValue(ADVERTISING_SERVER_RESPONSE, csServerResponse)) {
+			serverResponse.assign(csServerResponse.c_str());
+			LoadAds(serverResponse);
+			// when not remote, we assume ads are already bundled inside server pak
+			if (m_state == EAdState::eAS_FetchAds) {
+				m_state = EAdState::eAS_FetchedAdsPak;
+			}
+		} else {
+			m_state = EAdState::eAS_None;
+		}
+	}
+#endif
+}
+
+void CAdManager::LoadAds(const std::string& response) {
+	try {
+		m_upcomingAds.clear();
+		auto ads{ nlohmann::json::parse(response) };
+		auto& groups = ads["groups"];
+		for (size_t i = 0; i < groups.size(); i++) {
+			std::vector<SAdVersion> versions;
+			auto& jsonVersions = groups[i]["versions"];
+			for (size_t j = 0; j < jsonVersions.size(); j++) {
+				versions.emplace_back(SAdVersion{
+					.id = jsonVersions[j]["id"].get<std::string>(),
+					.path = jsonVersions[j]["path"].get<std::string>(),
+					.aspectRatio = jsonVersions[j]["aspectRatio"].get<float>(),
+					});
+			}
+			m_upcomingAds.emplace_back(SAdGroup{
+				.id = groups[i]["id"].get<std::string>(),
+				.viewId = groups[i]["viewId"].get<std::string>(),
+				.versions = std::move(versions)
+				});
+		}
+		m_upcomingPakUrl = ads["resources"].get<std::string>();
+		m_state = EAdState::eAS_FetchedAds;
+	}
+	catch (nlohmann::json::exception& ex) {
+		CryLogAlways("$4Failed to parse ads response: %s", ex.what());
+		m_cycles[AD_CYCLE_ERROR] = m_time;
+		m_state = EAdState::eAS_Error;
+	}
 }
 
 void CAdManager::FetchAdsPak() {

--- a/Code/CryMP/Client/Advertising.cpp
+++ b/Code/CryMP/Client/Advertising.cpp
@@ -263,7 +263,7 @@ void CAdManager::DisplayAds() {
 								for (auto& version : ad->versions) {
 									float similarity = abs(version.aspectRatio - mapping.aspectRatio);
 
-									if (similarity < closest) {
+									if (similarity < closest && similarity < 0.5f) {
 										pVersionMaterial = FindMaterial(*ad, version);
 										if (pVersionMaterial) {
 											adVersion = &version;

--- a/Code/CryMP/Client/Advertising.cpp
+++ b/Code/CryMP/Client/Advertising.cpp
@@ -170,6 +170,7 @@ void CAdManager::DisplayAds() {
 		m_ads = std::move(m_upcomingAds);
 	}
 
+#ifdef REMOTE_ADS
 	if (m_upcomingPakPath != m_pakPath) {
 		if (!m_pakPath.empty()) {
 			if (gEnv->pCryPak->ClosePack(m_pakPath.c_str())) {
@@ -192,6 +193,7 @@ void CAdManager::DisplayAds() {
 			}
 		}
 	}
+#endif
 
 	if (m_ads.size() == 0) {
 		return;
@@ -495,6 +497,7 @@ void CAdManager::LoadAds(const std::string& response) {
 }
 
 void CAdManager::FetchAdsPak() {
+#ifdef REMOTE_ADS
 	gClient->GetFileCache()->Request(FileCacheRequest{
 		.fileURL = m_upcomingPakUrl,
 		.fileType = "pak",
@@ -512,6 +515,9 @@ void CAdManager::FetchAdsPak() {
 			}
 		}
 	});
+#else
+	m_state = EAdState::eAS_FetchedAdsPak;
+#endif
 }
 
 void CAdManager::CollectViewership(float delta) {

--- a/Code/CryMP/Client/Advertising.h
+++ b/Code/CryMP/Client/Advertising.h
@@ -107,6 +107,7 @@ public:
 
 private:
 	void CollectViewership(float delta);
+	void LoadAds(const std::string& response);
 	void FetchAds();
 	void FetchAdsPak();
 	void DisplayAds();


### PR DESCRIPTION
# Ads

<img width="1600" height="1000" alt="ScreenShot0041" src="https://github.com/user-attachments/assets/923dff90-8b9b-4e6f-967b-79909098a489" />

Instead of ads being provided by master, ads are now turned off by default unless server specifies ads resource in synched global value 3001.

The format is same as JSON from master:

```json
{
  "resources": "(empty string in this set-up)",
  "groups": [
    {
      "id": "Unique Ad Group ID",
      "viewId": "Unique Ad View ID (can be empty string in this ad serving set-up)",
      "versions": [
        {
          "id": "Unique Ad ID 1",
          "aspectRatio": 1,
          "path": "Path/To/Ad1/In/Pak.dds"
        },
        {
          "id": "Unique Ad ID 2",
          "aspectRatio": 2,
          "path": "Path/To/Ad2/In/Pak.dds"
        }
      ]
    }
  ]
}
```

## Ad group vs Ad version

As group represents ad as a whole. Imagine ad group as an ad for "SCAR is 30% off", this ad can have multiple versions with different aspect ratios. 

For example big billboard ad version has aspect ratio 1 while small road signs have aspect ratio of 2.

## Resources and View IDs

In this set-up `resources` and `viewId` fields are not used anymore. They were used in past to specify URL where PAK with ads is located and to track viewership of ads by individual players.

In current set-up the system assumes ads are already inside server pak and viewership is not tracked (perhaps in future).

## ads CVar

In past we had ads CVar that allowed players that played 25+ hours to disable ads. This is getting removed, since ads are turned off by default and are enabled by servers to serve billboards they wish, therefore it is not to be disabled if server enforces it.

## Example images

### Billboard ad

Here is an image of a billboard ad (aspect ratio 1). It contains two billboards in one since game reuses same texture for two different billboard geometries just with a different crop on Y axis. Ideal resolution is 512x512. Format must be DDS.

<img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/b5b484e2-8f29-4ada-a303-931e528f12a3" />

### Road sign ad

Here is an image of a road sign ad (aspect ratio 2). Unlike billboard ad, it contains a single alternative. Ideal resolution is 512x256. Format must be DDS.

<img width="512" height="256" alt="image" src="https://github.com/user-attachments/assets/6bd7ca8f-6126-4f3e-bb81-5aefdd07295f" />