### PR TITLE
Fix data race in SynchedStorage and further modernize it

### DIFF
--- a/Code/Cry3DEngine/TimeOfDay.cpp
+++ b/Code/Cry3DEngine/TimeOfDay.cpp
@@ -1042,18 +1042,18 @@ Vec3 TimeOfDay::CalculateSunDirection(const Vec3& sunRotation) const
 	return sunDirection;
 }
 
-void TimeOfDay::LoadCustomSettings(string xmlPath, float blendDuration)
+void TimeOfDay::LoadCustomSettings(const char* xmlPath, float blendDuration)
 {
-	if (xmlPath.empty())
+	if (!xmlPath || !*xmlPath)
 	{
 		this->RestoreLevelDefaults(blendDuration);
 		return;
 	}
 
-	XmlNodeRef node = gEnv->pSystem->LoadXmlFile(xmlPath.c_str());
+	XmlNodeRef node = gEnv->pSystem->LoadXmlFile(xmlPath);
 	if (!node)
 	{
-		CryLogWarningAlways("Failed to load custom ToD settings from '%s'", xmlPath.c_str());
+		CryLogWarningAlways("Failed to load custom ToD settings from '%s'", xmlPath);
 		return;
 	}
 
@@ -1067,7 +1067,7 @@ void TimeOfDay::LoadCustomSettings(string xmlPath, float blendDuration)
 		//CryMP: Keep current active clock settings when loading a custom visual ToD preset.
 		this->Update(true, true);
 
-		CryLog("$3[CryMP] Loaded custom ToD settings from '%s'", xmlPath.c_str());
+		CryLog("$3[CryMP] Loaded custom ToD settings from '%s'", xmlPath);
 		return;
 	}
 
@@ -1089,12 +1089,7 @@ void TimeOfDay::LoadCustomSettings(string xmlPath, float blendDuration)
 	m_transitionTime = 0.0f;
 	m_transitionDuration = std::max(blendDuration, 0.001f);
 
-	CryLog("$3[CryMP] Blending custom ToD settings from '%s' over %.2f seconds", xmlPath.c_str(), blendDuration);
-}
-
-void TimeOfDay::RestoreLevelDefaults()
-{
-	this->RestoreLevelDefaults(0.0f);
+	CryLog("$3[CryMP] Blending custom ToD settings from '%s' over %.2f seconds", xmlPath, blendDuration);
 }
 
 void TimeOfDay::RestoreLevelDefaults(float blendDuration)

--- a/Code/Cry3DEngine/TimeOfDay.h
+++ b/Code/Cry3DEngine/TimeOfDay.h
@@ -3,6 +3,7 @@
 #include <array>
 #include <variant>
 #include <vector>
+#include <string>
 #include <string_view>
 #include <functional>
 
@@ -142,7 +143,7 @@ private:
 	float m_transitionTargetStartTime = 0.0f;
 	float m_transitionTargetEndTime = 0.0f;
 
-	string m_activeCustomTodFile;
+	std::string m_activeCustomTodFile;
 
 	int m_updateCallbackCounter = 0;
 	std::vector<std::pair<int, std::function<void(bool, bool)>>> m_updateCallbacks;
@@ -189,7 +190,7 @@ public:
 	}
 
 	void DebugDraw() override;
-	void LoadCustomSettings(string xmlPath, float blendDuration = 0.0f) override;
+	void LoadCustomSettings(const char* xmlPath, float blendDuration = 0.0f) override;
 	float GetTransitionTime() const override 
 	{ 
 		return m_transitionTime; 
@@ -202,15 +203,12 @@ public:
 	{
 		return m_transitionDuration > 0.0f && m_transitionTime < m_transitionDuration; 
 	}
-	const string& GetActiveCustomTodFile() const override 
+	const char* GetActiveCustomTodFile() const override
 	{
-		return m_activeCustomTodFile;
+		return m_activeCustomTodFile.c_str();
 	}
 
 	////////////////////////////////////////////////////////////////////////////////
-
-	void RestoreLevelDefaults();
-	void RestoreLevelDefaults(float blendDuration);
 
 	int AddUpdateCallback(std::function<void(bool, bool)> callback);
 	void RemoveUpdateCallback(int id);
@@ -226,4 +224,6 @@ private:
 	void EvaluateVariables(std::vector<Variable>& outVars, const std::vector<Variable>& sourceVars, float time) const;
 
 	Vec3 CalculateSunDirection(const Vec3& sunRotation) const;
+
+	void RestoreLevelDefaults(float blendDuration = 0.0f);
 };

--- a/Code/CryCommon/Cry3DEngine/I3DEngine.h
+++ b/Code/CryCommon/Cry3DEngine/I3DEngine.h
@@ -1013,11 +1013,11 @@ struct ITimeOfDay
 	//CryMP:
 	virtual bool IsPaused() const = 0;
 	virtual void DebugDraw() = 0;
-	virtual void LoadCustomSettings(string xmlPath, float blendDuration = 0.0f) = 0;
+	virtual void LoadCustomSettings(const char* xmlPath, float blendDuration = 0.0f) = 0;
 	virtual float GetTransitionTime() const = 0;
 	virtual float GetTransitionDuration() const = 0;
 	virtual bool IsTransitioning() const = 0;
-	virtual const string& GetActiveCustomTodFile() const = 0;
+	virtual const char* GetActiveCustomTodFile() const = 0;
 };
 
 

--- a/Code/CryGame/ClientSynchedStorage.cpp
+++ b/Code/CryGame/ClientSynchedStorage.cpp
@@ -44,39 +44,39 @@ size_t CClientSynchedStorage::CResetMsg::GetSize()
 	CClientSynchedStorage::class::class(int _channelId, CServerSynchedStorage *pStorage, TSynchedKey _key, TSynchedValue &_value) \
 	:	CSetGlobalMsg(CClientSynchedStorage::msgdef, _channelId, pStorage, _key, _value) {}; \
 	EMessageSendResult CClientSynchedStorage::class::WritePayload(TSerialize ser, uint32 currentSeq, uint32 basisSeq) \
-{ m_pStorage->SerializeValue(ser, key, value, NTypelist::IndexOf<type, TSynchedValueTypes>::value); \
+{ m_pStorage->SerializeValue(ser, key, value, type); \
 	return eMSR_SentOk; }
 
 #define IMPLEMENT_IMMEDIATE_GLOBAL_MESSAGE(type) \
 	TSynchedKey		key; \
 	TSynchedValue value; \
-	SerializeValue(ser, key, value, NTypelist::IndexOf<type, TSynchedValueTypes>::value); \
+	SerializeValue(ser, key, value, type); \
 	return true;
 
 
 NET_IMPLEMENT_IMMEDIATE_MESSAGE(CClientSynchedStorage, SetGlobalBoolMsg, eNRT_ReliableUnordered, 0)
 {
-	IMPLEMENT_IMMEDIATE_GLOBAL_MESSAGE(bool);
+	IMPLEMENT_IMMEDIATE_GLOBAL_MESSAGE(SynchedValueType::Bool);
 }
 
 NET_IMPLEMENT_IMMEDIATE_MESSAGE(CClientSynchedStorage, SetGlobalFloatMsg, eNRT_ReliableUnordered, 0)
 {
-	IMPLEMENT_IMMEDIATE_GLOBAL_MESSAGE(float);
+	IMPLEMENT_IMMEDIATE_GLOBAL_MESSAGE(SynchedValueType::Float);
 }
 
 NET_IMPLEMENT_IMMEDIATE_MESSAGE(CClientSynchedStorage, SetGlobalIntMsg, eNRT_ReliableUnordered, 0)
 {
-	IMPLEMENT_IMMEDIATE_GLOBAL_MESSAGE(int);
+	IMPLEMENT_IMMEDIATE_GLOBAL_MESSAGE(SynchedValueType::Int);
 }
 
 NET_IMPLEMENT_IMMEDIATE_MESSAGE(CClientSynchedStorage, SetGlobalEntityIdMsg, eNRT_ReliableUnordered, 0)
 {
-	IMPLEMENT_IMMEDIATE_GLOBAL_MESSAGE(EntityId);
+	IMPLEMENT_IMMEDIATE_GLOBAL_MESSAGE(SynchedValueType::EntityId);
 }
 
 NET_IMPLEMENT_IMMEDIATE_MESSAGE(CClientSynchedStorage, SetGlobalStringMsg, eNRT_ReliableUnordered, 0)
 {
-	IMPLEMENT_IMMEDIATE_GLOBAL_MESSAGE(string);
+	IMPLEMENT_IMMEDIATE_GLOBAL_MESSAGE(SynchedValueType::String);
 }
 
 CClientSynchedStorage::CSetGlobalMsg::CSetGlobalMsg(const SNetMessageDef *pDef, int _channelId, CServerSynchedStorage *pStorage, TSynchedKey _key, TSynchedValue &_value)
@@ -103,11 +103,11 @@ size_t CClientSynchedStorage::CSetGlobalMsg::GetSize()
 	return sizeof (*this);
 };
 
-DEFINE_GLOBAL_MESSAGE(CSetGlobalBoolMsg, bool, SetGlobalBoolMsg);
-DEFINE_GLOBAL_MESSAGE(CSetGlobalFloatMsg, float, SetGlobalFloatMsg);
-DEFINE_GLOBAL_MESSAGE(CSetGlobalIntMsg, int, SetGlobalIntMsg);
-DEFINE_GLOBAL_MESSAGE(CSetGlobalEntityIdMsg, EntityId, SetGlobalEntityIdMsg);
-DEFINE_GLOBAL_MESSAGE(CSetGlobalStringMsg, string, SetGlobalStringMsg);
+DEFINE_GLOBAL_MESSAGE(CSetGlobalBoolMsg, SynchedValueType::Bool, SetGlobalBoolMsg);
+DEFINE_GLOBAL_MESSAGE(CSetGlobalFloatMsg, SynchedValueType::Float, SetGlobalFloatMsg);
+DEFINE_GLOBAL_MESSAGE(CSetGlobalIntMsg, SynchedValueType::Int, SetGlobalIntMsg);
+DEFINE_GLOBAL_MESSAGE(CSetGlobalEntityIdMsg, SynchedValueType::EntityId, SetGlobalEntityIdMsg);
+DEFINE_GLOBAL_MESSAGE(CSetGlobalStringMsg, SynchedValueType::String, SetGlobalStringMsg);
 
 #undef DEFINE_GLOBAL_MESSAGE
 #undef IMPLEMENT_IMMEDIATE_GLOBAL_MESSAGE
@@ -156,7 +156,7 @@ NET_IMPLEMENT_IMMEDIATE_MESSAGE(CClientSynchedStorage, SetChannelStringMsg, eNRT
 	:	CSetEntityMsg(CClientSynchedStorage::msgdef, _channelId, pStorage, id, _key, _value) {}; \
 	EMessageSendResult CClientSynchedStorage::class::WritePayload(TSerialize ser, uint32 currentSeq, uint32 basisSeq) \
 { ser.Value("entityId", entityId, /* 'eid' */0x00656964); \
-	m_pStorage->SerializeValue(ser, key, value, NTypelist::IndexOf<type, TSynchedValueTypes>::value); \
+	m_pStorage->SerializeEntityValue(ser, entityId, key, value, type); \
 	return eMSR_SentOk; }
 
 #define IMPLEMENT_IMMEDIATE_ENTITY_MESSAGE(type) \
@@ -164,33 +164,33 @@ NET_IMPLEMENT_IMMEDIATE_MESSAGE(CClientSynchedStorage, SetChannelStringMsg, eNRT
 	TSynchedValue value; \
 	EntityId			id; \
 	ser.Value("entityId", id, /* 'eid' */0x00656964); \
-	SerializeEntityValue(ser, id, key, value, NTypelist::IndexOf<type, TSynchedValueTypes>::value); \
+	SerializeEntityValue(ser, id, key, value, type); \
 	return true;
 
 
 NET_IMPLEMENT_IMMEDIATE_MESSAGE(CClientSynchedStorage, SetEntityBoolMsg, eNRT_ReliableUnordered, eMPF_AfterSpawning)
 {
-	IMPLEMENT_IMMEDIATE_ENTITY_MESSAGE(bool);
+	IMPLEMENT_IMMEDIATE_ENTITY_MESSAGE(SynchedValueType::Bool);
 }
 
 NET_IMPLEMENT_IMMEDIATE_MESSAGE(CClientSynchedStorage, SetEntityFloatMsg, eNRT_ReliableUnordered, eMPF_AfterSpawning)
 {
-	IMPLEMENT_IMMEDIATE_ENTITY_MESSAGE(float);
+	IMPLEMENT_IMMEDIATE_ENTITY_MESSAGE(SynchedValueType::Float);
 }
 
 NET_IMPLEMENT_IMMEDIATE_MESSAGE(CClientSynchedStorage, SetEntityIntMsg, eNRT_ReliableUnordered, eMPF_AfterSpawning)
 {
-	IMPLEMENT_IMMEDIATE_ENTITY_MESSAGE(int);
+	IMPLEMENT_IMMEDIATE_ENTITY_MESSAGE(SynchedValueType::Int);
 }
 
 NET_IMPLEMENT_IMMEDIATE_MESSAGE(CClientSynchedStorage, SetEntityEntityIdMsg, eNRT_ReliableUnordered, eMPF_AfterSpawning)
 {
-	IMPLEMENT_IMMEDIATE_ENTITY_MESSAGE(EntityId);
+	IMPLEMENT_IMMEDIATE_ENTITY_MESSAGE(SynchedValueType::EntityId);
 }
 
 NET_IMPLEMENT_IMMEDIATE_MESSAGE(CClientSynchedStorage, SetEntityStringMsg, eNRT_ReliableUnordered, eMPF_AfterSpawning)
 {
-	IMPLEMENT_IMMEDIATE_ENTITY_MESSAGE(string);
+	IMPLEMENT_IMMEDIATE_ENTITY_MESSAGE(SynchedValueType::String);
 }
 
 CClientSynchedStorage::CSetEntityMsg::CSetEntityMsg(const SNetMessageDef *pDef, int _channelId, CServerSynchedStorage *pStorage, EntityId id, TSynchedKey _key, TSynchedValue &_value)
@@ -218,11 +218,11 @@ size_t CClientSynchedStorage::CSetEntityMsg::GetSize()
 	return sizeof (*this);
 };
 
-DEFINE_ENTITY_MESSAGE(CSetEntityBoolMsg, bool, SetEntityBoolMsg);
-DEFINE_ENTITY_MESSAGE(CSetEntityFloatMsg, float, SetEntityFloatMsg);
-DEFINE_ENTITY_MESSAGE(CSetEntityIntMsg, int, SetEntityIntMsg);
-DEFINE_ENTITY_MESSAGE(CSetEntityEntityIdMsg, EntityId, SetEntityEntityIdMsg);
-DEFINE_ENTITY_MESSAGE(CSetEntityStringMsg, string, SetEntityStringMsg);
+DEFINE_ENTITY_MESSAGE(CSetEntityBoolMsg, SynchedValueType::Bool, SetEntityBoolMsg);
+DEFINE_ENTITY_MESSAGE(CSetEntityFloatMsg, SynchedValueType::Float, SetEntityFloatMsg);
+DEFINE_ENTITY_MESSAGE(CSetEntityIntMsg, SynchedValueType::Int, SetEntityIntMsg);
+DEFINE_ENTITY_MESSAGE(CSetEntityEntityIdMsg, SynchedValueType::EntityId, SetEntityEntityIdMsg);
+DEFINE_ENTITY_MESSAGE(CSetEntityStringMsg, SynchedValueType::String, SetEntityStringMsg);
 
 #undef DEFINE_ENTITY_MESSAGE
 #undef IMPLEMENT_IMMEDIATE_ENTITY_MESSAGE

--- a/Code/CryGame/ClientSynchedStorage.h
+++ b/Code/CryGame/ClientSynchedStorage.h
@@ -23,10 +23,10 @@ class classname: public CSetGlobalMsg \
 
 class CServerSynchedStorage;
 
-class CClientSynchedStorage: public CNetMessageSinkHelper<CClientSynchedStorage, CSynchedStorage>
+class CClientSynchedStorage final : public CNetMessageSinkHelper<CClientSynchedStorage, CSynchedStorage>
 {
 public:
-	CClientSynchedStorage(IGameFramework *pGameFramework)
+	explicit CClientSynchedStorage(IGameFramework* pGameFramework)
 	{
 		m_pGameFramework = pGameFramework;
 	}

--- a/Code/CryGame/Game.cpp
+++ b/Code/CryGame/Game.cpp
@@ -643,13 +643,13 @@ void CGame::OnActionEvent(const SActionEvent& event)
 	case eAE_serverIp:
 		if (gEnv->bServer && GetServerSynchedStorage())
 		{
-			GetServerSynchedStorage()->SetGlobalValue(GLOBAL_SERVER_IP_KEY, string(event.m_description));
+			GetServerSynchedStorage()->SetGlobalValue(GLOBAL_SERVER_IP_KEY, StringTools::SafeString(event.m_description));
 			GetServerSynchedStorage()->SetGlobalValue(GLOBAL_SERVER_PUBLIC_PORT_KEY, event.m_value);
 		}
 		break;
 	case eAE_serverName:
 		if (gEnv->bServer && GetServerSynchedStorage())
-			GetServerSynchedStorage()->SetGlobalValue(GLOBAL_SERVER_NAME_KEY, string(event.m_description));
+			GetServerSynchedStorage()->SetGlobalValue(GLOBAL_SERVER_NAME_KEY, StringTools::SafeString(event.m_description));
 		break;
 	case  eAE_languageChanged:
 		ReloadFlashInstances();

--- a/Code/CryGame/GameRules.cpp
+++ b/Code/CryGame/GameRules.cpp
@@ -4612,10 +4612,10 @@ void CGameRules::OnSetActorModel(CActor* pActor, int currTeamId)
 	const int CURR_KEY_MODEL = KEY_MODEL + currTeamId;
 	const int TEAM_ID_NK = 1;
 
-	string model;
+	std::string model;
 	if (GetSynchedEntityValue(playerId, CURR_KEY_MODEL, model) && model.length() > 0)
 	{
-		pActor->SetFileModel(model.c_str());
+		pActor->SetFileModel(model);
 	}
 	else if (isPlayer)
 	{

--- a/Code/CryGame/GameRules.h
+++ b/Code/CryGame/GameRules.h
@@ -476,10 +476,10 @@ public:
 		return g_pGame->GetSynchedStorage()->GetGlobalValue(key, value);
 	}
 
-	int GetSynchedGlobalValueType(TSynchedKey key) const
+	SynchedValueType GetSynchedGlobalValueType(TSynchedKey key) const
 	{
 		if (!g_pGame->GetSynchedStorage())
-			return eSVT_None;
+			return SynchedValueType::None;
 		return g_pGame->GetSynchedStorage()->GetGlobalValueType(key);
 	}
 
@@ -503,7 +503,7 @@ public:
 		return g_pGame->GetSynchedStorage()->GetEntityValue(id, key, value);
 	}
 	
-	int GetSynchedEntityValueType(EntityId id, TSynchedKey key) const
+	SynchedValueType GetSynchedEntityValueType(EntityId id, TSynchedKey key) const
 	{
 		return g_pGame->GetSynchedStorage()->GetEntityValueType(id, key);
 	}

--- a/Code/CryGame/HUD/HUDObituary.cpp
+++ b/Code/CryGame/HUD/HUDObituary.cpp
@@ -2,6 +2,7 @@
 // Crytek Source File.
 // Copyright (C) Crytek GmbH, 2001-2008.
 // -------------------------------------------------------------------------
+#include "CryCommon/CryCore/CrySizer.h"
 #include "CryCommon/CrySystem/ISystem.h"
 #include "HUDObituary.h"
 #include "CryCommon/CryAction/IUIDraw.h"

--- a/Code/CryGame/HUD/HUDPowerStruggle.cpp
+++ b/Code/CryGame/HUD/HUDPowerStruggle.cpp
@@ -1996,7 +1996,7 @@ void CHUDPowerStruggle::SetLastBuyMenuPage(BuyMenuPage page, bool updateTime)
 void CHUDPowerStruggle::GetTeamStatus(int teamId, float& power, float& hq, int& controlledAliens, EntityId& prototypeFactoryId)
 {
 	power = 0.0f;
-	if (m_pGameRules->GetSynchedGlobalValueType(300 + teamId) == eSVT_Int)
+	if (m_pGameRules->GetSynchedGlobalValueType(300 + teamId) == SynchedValueType::Int)
 	{
 		int p;
 		m_pGameRules->GetSynchedGlobalValue(300 + teamId, p);

--- a/Code/CryGame/HUD/HUDScore.cpp
+++ b/Code/CryGame/HUD/HUDScore.cpp
@@ -304,8 +304,8 @@ void CHUDScore::Render()
 	if (!pClientActor)
 		return;
 
-	string svr_name = "";
-	string svr_ip = "";
+	std::string svr_name;
+	std::string svr_ip;
 
 	pGameRules->GetSynchedGlobalValue(GLOBAL_SERVER_IP_KEY, svr_ip);
 	pGameRules->GetSynchedGlobalValue(GLOBAL_SERVER_NAME_KEY, svr_name);

--- a/Code/CryGame/HUD/HUDScore.h
+++ b/Code/CryGame/HUD/HUDScore.h
@@ -112,8 +112,8 @@ private:
 	int				m_currentClientTeam;
 	bool			m_bShow;
 	float			m_lastShowSwitch;
-	string		m_currentServer;
-	string    m_currentServerIp;	
+	std::string m_currentServer;
+	std::string m_currentServerIp;
 	CGameFlashAnimation *m_pFlashBoard;
 	SRankStats m_rankStats;
 

--- a/Code/CryGame/HUD/HUDTextArea.cpp
+++ b/Code/CryGame/HUD/HUDTextArea.cpp
@@ -2,6 +2,7 @@
 // Crytek Source File.
 // Copyright (C) Crytek GmbH, 2001-2008.
 // -------------------------------------------------------------------------
+#include "CryCommon/CryCore/CrySizer.h"
 #include "CryCommon/CrySystem/ISystem.h"
 #include "CryCommon/CryFont/IFont.h"
 #include "HUDTextArea.h"

--- a/Code/CryGame/ScriptBind_GameRules.cpp
+++ b/Code/CryGame/ScriptBind_GameRules.cpp
@@ -11,6 +11,8 @@ History:
 
 *************************************************************************/
 #include "CryCommon/CrySystem/ISystem.h"
+#include "Library/StringTools.h"
+
 #include "ScriptBind_GameRules.h"
 #include "GameRules.h"
 #include "Actors/Actor.h"
@@ -1912,9 +1914,9 @@ int CScriptBind_GameRules::SetSynchedGlobalValue(IFunctionHandler* pH, int key)
 		{
 		case svtString:
 		{
-			const char* s = 0;
+			const char* s = nullptr;
 			pH->GetParam(2, s);
-			pGameRules->SetSynchedGlobalValue(key, string(s));
+			pGameRules->SetSynchedGlobalValue(key, StringTools::SafeString(s));
 		}
 		break;
 		case svtPointer:
@@ -1956,43 +1958,43 @@ int CScriptBind_GameRules::GetSynchedGlobalValue(IFunctionHandler* pH, int key)
 {
 	CGameRules* pGameRules = GetGameRules(pH);
 
-	int type = pGameRules->GetSynchedGlobalValueType(key);
-	if (type == eSVT_None)
+	SynchedValueType type = pGameRules->GetSynchedGlobalValueType(key);
+	if (type == SynchedValueType::None)
 		return pH->EndFunction();
 
 	switch (type)
 	{
-	case eSVT_Bool:
+	case SynchedValueType::Bool:
 	{
 		bool b;
 		pGameRules->GetSynchedGlobalValue(key, b);
 		return pH->EndFunction(b);
 	}
 	break;
-	case eSVT_Float:
+	case SynchedValueType::Float:
 	{
 		float f;
 		pGameRules->GetSynchedGlobalValue(key, f);
 		return pH->EndFunction(f);
 	}
 	break;
-	case eSVT_Int:
+	case SynchedValueType::Int:
 	{
 		int i;
 		pGameRules->GetSynchedGlobalValue(key, i);
 		return pH->EndFunction(i);
 	}
 	break;
-	case eSVT_EntityId:
+	case SynchedValueType::EntityId:
 	{
 		EntityId e;
 		pGameRules->GetSynchedGlobalValue(key, e);
 		return pH->EndFunction(ScriptHandle(e));
 	}
 	break;
-	case eSVT_String:
+	case SynchedValueType::String:
 	{
-		static string s;
+		std::string s;
 		pGameRules->GetSynchedGlobalValue(key, s);
 		return pH->EndFunction(s.c_str());
 	}
@@ -2017,9 +2019,9 @@ int CScriptBind_GameRules::SetSynchedEntityValue(IFunctionHandler* pH, ScriptHan
 		{
 		case svtString:
 		{
-			const char* s = 0;
+			const char* s = nullptr;
 			pH->GetParam(3, s);
-			pGameRules->SetSynchedEntityValue(id, key, string(s));
+			pGameRules->SetSynchedEntityValue(id, key, StringTools::SafeString(s));
 		}
 		break;
 		case svtPointer:
@@ -2061,43 +2063,43 @@ int CScriptBind_GameRules::GetSynchedEntityValue(IFunctionHandler* pH, ScriptHan
 	CGameRules* pGameRules = GetGameRules(pH);
 
 	EntityId id = (EntityId)entityId.n;
-	int type = pGameRules->GetSynchedEntityValueType(id, key);
-	if (type == eSVT_None)
+	SynchedValueType type = pGameRules->GetSynchedEntityValueType(id, key);
+	if (type == SynchedValueType::None)
 		return pH->EndFunction();
 
 	switch (type)
 	{
-	case eSVT_Bool:
+	case SynchedValueType::Bool:
 	{
 		bool b;
 		pGameRules->GetSynchedEntityValue(id, key, b);
 		return pH->EndFunction(b);
 	}
 	break;
-	case eSVT_Float:
+	case SynchedValueType::Float:
 	{
 		float f;
 		pGameRules->GetSynchedEntityValue(id, key, f);
 		return pH->EndFunction(f);
 	}
 	break;
-	case eSVT_Int:
+	case SynchedValueType::Int:
 	{
 		int i;
 		pGameRules->GetSynchedEntityValue(id, key, i);
 		return pH->EndFunction(i);
 	}
 	break;
-	case eSVT_EntityId:
+	case SynchedValueType::EntityId:
 	{
 		EntityId e;
 		pGameRules->GetSynchedEntityValue(id, key, e);
 		return pH->EndFunction(ScriptHandle(e));
 	}
 	break;
-	case eSVT_String:
+	case SynchedValueType::String:
 	{
-		static string s;
+		std::string s;
 		pGameRules->GetSynchedEntityValue(id, key, s);
 		return pH->EndFunction(s.c_str());
 	}

--- a/Code/CryGame/ServerSynchedStorage.cpp
+++ b/Code/CryGame/ServerSynchedStorage.cpp
@@ -1,5 +1,8 @@
-#include "ServerSynchedStorage.h"
+#include "CryCommon/CryAction/IGameFramework.h"
 #include "CryCommon/CryEntitySystem/IEntitySystem.h"
+#include "CryCommon/CrySystem/gEnv.h"
+
+#include "ServerSynchedStorage.h"
 
 CServerSynchedStorage::SChannel *CServerSynchedStorage::GetChannel(int channelId)
 {
@@ -120,21 +123,21 @@ void CServerSynchedStorage::AddToGlobalQueueFor(int channelId, TSynchedKey key)
 
 	CClientSynchedStorage::CSetGlobalMsg *pMsg = nullptr;
 
-	switch (value.GetType())
+	switch (static_cast<SynchedValueType>(value.index()))
 	{
-		case eSVT_Bool:
+		case SynchedValueType::Bool:
 			pMsg = new CClientSynchedStorage::CSetGlobalBoolMsg(channelId, this, key, value);
 			break;
-		case eSVT_Float:
+		case SynchedValueType::Float:
 			pMsg = new CClientSynchedStorage::CSetGlobalFloatMsg(channelId, this, key, value);
 			break;
-		case eSVT_Int:
+		case SynchedValueType::Int:
 			pMsg = new CClientSynchedStorage::CSetGlobalIntMsg(channelId, this, key, value);
 			break;
-		case eSVT_EntityId:
+		case SynchedValueType::EntityId:
 			pMsg = new CClientSynchedStorage::CSetGlobalEntityIdMsg(channelId, this, key, value);
 			break;
-		case eSVT_String:
+		case SynchedValueType::String:
 			pMsg = new CClientSynchedStorage::CSetGlobalStringMsg(channelId, this, key, value);
 			break;
 	}
@@ -163,21 +166,21 @@ void CServerSynchedStorage::AddToEntityQueueFor(int channelId, EntityId entityId
 
 	CClientSynchedStorage::CSetEntityMsg *pMsg = nullptr;
 
-	switch (value.GetType())
+	switch (static_cast<SynchedValueType>(value.index()))
 	{
-		case eSVT_Bool:
+		case SynchedValueType::Bool:
 			pMsg = new CClientSynchedStorage::CSetEntityBoolMsg(channelId, this, entityId, key, value);
 			break;
-		case eSVT_Float:
+		case SynchedValueType::Float:
 			pMsg = new CClientSynchedStorage::CSetEntityFloatMsg(channelId, this, entityId, key, value);
 			break;
-		case eSVT_Int:
+		case SynchedValueType::Int:
 			pMsg = new CClientSynchedStorage::CSetEntityIntMsg(channelId, this, entityId, key, value);
 			break;
-		case eSVT_EntityId:
+		case SynchedValueType::EntityId:
 			pMsg = new CClientSynchedStorage::CSetEntityEntityIdMsg(channelId, this, entityId, key, value);
 			break;
-		case eSVT_String:
+		case SynchedValueType::String:
 			pMsg = new CClientSynchedStorage::CSetEntityStringMsg(channelId, this, entityId, key, value);
 			break;
 	}
@@ -198,43 +201,32 @@ void CServerSynchedStorage::FullSynch(int channelId, bool reset)
 		ResetChannel(channelId);
 	}
 
-	for (const auto & item : m_globalStorage)
+	for (const auto& [key, value] : m_globalStorage)
 	{
-		AddToGlobalQueueFor(channelId, item.first);
+		AddToGlobalQueueFor(channelId, key);
 	}
 
-	ClearNonExistingEntities();
+	// Remove non-existent entities
+	std::erase_if(m_entityStorage, [pEntitySystem = gEnv->pEntitySystem](const auto& item) {
+		const auto& [entityId, storage] = item;
+		return pEntitySystem->GetEntity(entityId) == nullptr;
+	});
 
-	for (const auto & entityItem : m_entityStorage)
+	for (const auto& [entityId, storage] : m_entityStorage)
 	{
-		for (const auto & item : entityItem.second)
+		for (const auto& [key, value] : storage)
 		{
-			AddToEntityQueueFor(channelId, entityItem.first, item.first);
+			AddToEntityQueueFor(channelId, entityId, key);
 		}
 	}
 }
 
-void CServerSynchedStorage::ClearNonExistingEntities()
-{
-	for (auto it = m_entityStorage.begin(); it != m_entityStorage.end(); )
-	{
-		if (gEnv->pEntitySystem->GetEntity(it->first) == nullptr)
-		{
-			it = m_entityStorage.erase(it);
-		}
-		else
-		{
-			++it;
-		}
-	}
-}
-
-void CServerSynchedStorage::OnGlobalChanged(TSynchedKey key, const TSynchedValue & value)
+void CServerSynchedStorage::OnGlobalChanged(TSynchedKey key)
 {
 	AddToGlobalQueue(key);
 }
 
-void CServerSynchedStorage::OnEntityChanged(EntityId entityId, TSynchedKey key, const TSynchedValue & value)
+void CServerSynchedStorage::OnEntityChanged(EntityId entityId, TSynchedKey key)
 {
 	AddToEntityQueue(entityId, key);
 }

--- a/Code/CryGame/ServerSynchedStorage.h
+++ b/Code/CryGame/ServerSynchedStorage.h
@@ -2,7 +2,7 @@
 
 #include "ClientSynchedStorage.h"
 
-class CServerSynchedStorage : public CNetMessageSinkHelper<CServerSynchedStorage, CSynchedStorage>
+class CServerSynchedStorage final : public CNetMessageSinkHelper<CServerSynchedStorage, CSynchedStorage>
 {
 	struct SChannel
 	{
@@ -93,7 +93,7 @@ class CServerSynchedStorage : public CNetMessageSinkHelper<CServerSynchedStorage
 	void AddToEntityQueueFor(int channelId, EntityId entityId, TSynchedKey key);
 
 public:
-	CServerSynchedStorage(IGameFramework *pGameFramework)
+	explicit CServerSynchedStorage(IGameFramework* pGameFramework)
 	{
 		m_pGameFramework = pGameFramework;
 	}
@@ -110,7 +110,6 @@ public:
 	void OnClientEnteredGame(int channelId);
 
 protected:
-	void OnGlobalChanged(TSynchedKey key, const TSynchedValue & value) override;
-	void OnEntityChanged(EntityId entityId, TSynchedKey key, const TSynchedValue & value) override;
-	void ClearNonExistingEntities();
+	void OnGlobalChanged(TSynchedKey key) override;
+	void OnEntityChanged(EntityId entityId, TSynchedKey key) override;
 };

--- a/Code/CryGame/SynchedStorage.cpp
+++ b/Code/CryGame/SynchedStorage.cpp
@@ -3,42 +3,18 @@
 
 #include "SynchedStorage.h"
 
-static void DumpValue(TSynchedKey key, const TSynchedValue & value)
+struct DumpVisitor
 {
-	switch(value.GetType())
-	{
-		case eSVT_Bool:
-		{
-			CryLogAlways("  %.08d -     bool: %s", key, *value.GetPtr<bool>() ? "true" : "false");
-			break;
-		}
-		case eSVT_Float:
-		{
-			CryLogAlways("  %.08d -    float: %f", key, *value.GetPtr<float>());
-			break;
-		}
-		case eSVT_Int:
-		{
-			CryLogAlways("  %.08d -      int: %d", key, *value.GetPtr<int>());
-			break;
-		}
-		case eSVT_EntityId:
-		{
-			CryLogAlways("  %.08d - entityId: %.08x", key, *value.GetPtr<EntityId>());
-			break;
-		}
-		case eSVT_String:
-		{
-			CryLogAlways("  %.08d -  string: %s", key, value.GetPtr<string>()->c_str());
-			break;
-		}
-		default:
-		{
-			CryLogAlways("  %.08d - unknown: %.08x", key, *value.GetPtr<uint32>());
-			break;
-		}
-	}
-}
+	TSynchedKey key{};
+
+	explicit DumpVisitor(TSynchedKey key) : key(key) {}
+
+	void operator()(bool v)               { CryLogAlways("  %.08u -     bool: %s", key, v ? "true" : "false"); }
+	void operator()(float v)              { CryLogAlways("  %.08u -    float: %f", key, v); }
+	void operator()(int v)                { CryLogAlways("  %.08u -      int: %d", key, v); }
+	void operator()(EntityId v)           { CryLogAlways("  %.08u - entityId: %u", key, v); }
+	void operator()(const std::string& v) { CryLogAlways("  %.08u -   string: %s", key, v.c_str()); }
+};
 
 void CSynchedStorage::Reset()
 {
@@ -52,225 +28,133 @@ void CSynchedStorage::Dump()
 {
 	std::lock_guard lock(m_mutex);
 
-	CryLogAlways("---------------------------");
-	CryLogAlways(" SYNCHED STORAGE DUMP");
-	CryLogAlways("---------------------------\n");
+	CryLogAlways("-------------------------------- SynchedStorage --------------------------------");
 	CryLogAlways("Globals:");
 
-	for (const auto & item : m_globalStorage)
+	for (const auto& [key, value] : m_globalStorage)
 	{
-		DumpValue(item.first, item.second);
+		std::visit(DumpVisitor{key}, value);
 	}
 
-	CryLogAlways("---------------------------\n");
-
-	for (const auto & entityItem : m_entityStorage)
+	for (const auto& [entityId, storage] : m_entityStorage)
 	{
-		IEntity *pEntity = gEnv->pEntitySystem->GetEntity(entityItem.first);
-		const char *name = pEntity ? pEntity->GetName() : "null";
+		IEntity* pEntity = gEnv->pEntitySystem->GetEntity(entityId);
+		const char* name = pEntity ? pEntity->GetName() : "null";
 
-		CryLogAlways("Entity %.08d(%s)", entityItem.first, name);
+		CryLogAlways("Entity %u (%s):", entityId, name);
 
-		for (const auto & item : entityItem.second)
+		for (const auto& [key, value] : storage)
 		{
-			DumpValue(item.first, item.second);
+			std::visit(DumpVisitor{key}, value);
 		}
 	}
+
+	CryLogAlways("--------------------------------------------------------------------------------");
 }
 
-void CSynchedStorage::SerializeValue(TSerialize ser, TSynchedKey & key, TSynchedValue & value, int type)
+void CSynchedStorage::SerializeValue(TSerialize ser, TSynchedKey& key, TSynchedValue& value, SynchedValueType type)
 {
 	ser.Value("key", key, /* 'ssk' */ 0x0073736B);
 
+	const auto impl = [&]<class T>(int policy) {
+		T v{};
+
+		if (ser.IsWriting())
+		{
+			T* p = std::get_if<T>(&value);
+			if (p)
+			{
+				v = *p;
+			}
+		}
+
+		ser.Value("value", v, policy);
+
+		if (ser.IsReading())
+		{
+			SetGlobalValue(key, v);
+		}
+	};
+
 	switch (type)
 	{
-		case eSVT_Bool:
+		case SynchedValueType::Bool:
 		{
-			bool b;
-
-			if (ser.IsWriting())
-			{
-				b = *value.GetPtr<bool>();
-			}
-
-			ser.Value("value", b, 'bool');
-
-			if (ser.IsReading())
-			{
-				SetGlobalValue(key, b);
-			}
-
+			impl.operator()<bool>(/* 'bool' */ 0x626F6F6C);
 			break;
 		}
-		case eSVT_Float:
+		case SynchedValueType::Float:
 		{
-			float f;
-
-			if (ser.IsWriting())
-			{
-				f = *value.GetPtr<float>();
-			}
-
-			ser.Value("value", f, 'ssfl');
-
-			if (ser.IsReading())
-			{
-				SetGlobalValue(key, f);
-			}
-
+			impl.operator()<float>(/* 'ssfl' */ 0x7373666C);
 			break;
 		}
-		case eSVT_Int:
+		case SynchedValueType::Int:
 		{
-			int i;
-
-			if (ser.IsWriting())
-			{
-				i = *value.GetPtr<int>();
-			}
-
-			ser.Value("value", i, /* 'ssi' */ 0x00737369);
-
-			if (ser.IsReading())
-			{
-				SetGlobalValue(key, i);
-			}
-
+			impl.operator()<int>(/* 'ssi' */ 0x00737369);
 			break;
 		}
-		case eSVT_EntityId:
+		case SynchedValueType::EntityId:
 		{
-			EntityId e;
-
-			if (ser.IsWriting())
-			{
-				e = *value.GetPtr<EntityId>();
-			}
-
-			ser.Value("value", e, /* 'eid' */0x00656964);
-
-			if (ser.IsReading())
-			{
-				SetGlobalValue(key, e);
-			}
-
+			impl.operator()<EntityId>(/* 'eid' */ 0x00656964);
 			break;
 		}
-		case eSVT_String:
+		case SynchedValueType::String:
 		{
-			string s;
-
-			if (ser.IsWriting())
-			{
-				s = *value.GetPtr<string>();
-			}
-
-			ser.Value("value", s);
-
-			if (ser.IsReading())
-			{
-				SetGlobalValue(key, s);
-			}
-
+			impl.operator()<std::string>(0);
 			break;
 		}
 	}
 }
 
-void CSynchedStorage::SerializeEntityValue(TSerialize ser, EntityId id, TSynchedKey & key, TSynchedValue & value, int type)
+void CSynchedStorage::SerializeEntityValue(TSerialize ser, EntityId id, TSynchedKey& key, TSynchedValue& value, SynchedValueType type)
 {
 	ser.Value("key", key, /* 'ssk' */ 0x0073736B);
 
+	const auto impl = [&]<class T>(int policy) {
+		T v{};
+
+		if (ser.IsWriting())
+		{
+			T* p = std::get_if<T>(&value);
+			if (p)
+			{
+				v = *p;
+			}
+		}
+
+		ser.Value("value", v, policy);
+
+		if (ser.IsReading())
+		{
+			SetEntityValue(id, key, v);
+		}
+	};
+
 	switch (type)
 	{
-		case eSVT_Bool:
+		case SynchedValueType::Bool:
 		{
-			bool b;
-
-			if (ser.IsWriting())
-			{
-				b = *value.GetPtr<bool>();
-			}
-
-			ser.Value("value", b, 'bool');
-
-			if (ser.IsReading())
-			{
-				SetEntityValue(id, key, b);
-			}
-
+			impl.operator()<bool>(/* 'bool' */ 0x626F6F6C);
 			break;
 		}
-		case eSVT_Float:
+		case SynchedValueType::Float:
 		{
-			float f;
-
-			if (ser.IsWriting())
-			{
-				f = *value.GetPtr<float>();
-			}
-
-			ser.Value("value", f, 'ssfl');
-
-			if (ser.IsReading())
-			{
-				SetEntityValue(id, key, f);
-			}
-
+			impl.operator()<float>(/* 'ssfl' */ 0x7373666C);
 			break;
 		}
-		case eSVT_Int:
+		case SynchedValueType::Int:
 		{
-			int i;
-
-			if (ser.IsWriting())
-			{
-				i = *value.GetPtr<int>();
-			}
-
-			ser.Value("value", i, /* 'ssi' */ 0x00737369);
-
-			if (ser.IsReading())
-			{
-				SetEntityValue(id, key, i);
-			}
-
+			impl.operator()<int>(/* 'ssi' */ 0x00737369);
 			break;
 		}
-		case eSVT_EntityId:
+		case SynchedValueType::EntityId:
 		{
-			EntityId e;
-
-			if (ser.IsWriting())
-			{
-				e = *value.GetPtr<EntityId>();
-			}
-
-			ser.Value("value", e, /* 'eid' */0x00656964);
-
-			if (ser.IsReading())
-			{
-				SetEntityValue(id, key, e);
-			}
-
+			impl.operator()<EntityId>(/* 'eid' */ 0x00656964);
 			break;
 		}
-		case eSVT_String:
+		case SynchedValueType::String:
 		{
-			string s;
-
-			if (ser.IsWriting())
-			{
-				s = *value.GetPtr<string>();
-			}
-
-			ser.Value("value", s);
-
-			if (ser.IsReading())
-			{
-				SetEntityValue(id, key, s);
-			}
-
+			impl.operator()<std::string>(0);
 			break;
 		}
 	}

--- a/Code/CryGame/SynchedStorage.h
+++ b/Code/CryGame/SynchedStorage.h
@@ -1,39 +1,44 @@
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <mutex>
+#include <string>
+#include <variant>
 
 #include "CryCommon/CryNetwork/INetwork.h"
-#include "CryCommon/CryAction/IGameFramework.h"
-#include "CryCommon/CryCore/ConfigurableVariant.h"
 
-using TSynchedValueTypes = NTypelist::CConstruct<bool, float, int, EntityId, string>::TType;
+struct IGameFramework;
 
-enum ESynchedValueTypes
+using TSynchedKey = std::uint16_t;
+using TSynchedValue = std::variant<bool, float, int, EntityId, std::string>;
+
+enum class SynchedValueType
 {
-	eSVT_None     = -1,
-	eSVT_Bool     = NTypelist::IndexOf<bool,     TSynchedValueTypes>::value,
-	eSVT_Float    = NTypelist::IndexOf<float,    TSynchedValueTypes>::value,
-	eSVT_Int      = NTypelist::IndexOf<int,      TSynchedValueTypes>::value,
-	eSVT_EntityId = NTypelist::IndexOf<EntityId, TSynchedValueTypes>::value,
-	eSVT_String   = NTypelist::IndexOf<string,   TSynchedValueTypes>::value,
+	None = -1,
+	Bool = 0,
+	Float = 1,
+	Int = 2,
+	EntityId = 3,
+	String = 4,
 };
 
-using TSynchedKey = uint16;
-using TSynchedValue = CConfigurableVariant<TSynchedValueTypes, sizeof (void*)>;
+static_assert(static_cast<SynchedValueType>(TSynchedValue(bool{}).index()) == SynchedValueType::Bool);
+static_assert(static_cast<SynchedValueType>(TSynchedValue(float{}).index()) == SynchedValueType::Float);
+static_assert(static_cast<SynchedValueType>(TSynchedValue(int{}).index()) == SynchedValueType::Int);
+static_assert(static_cast<SynchedValueType>(TSynchedValue(EntityId{}).index()) == SynchedValueType::EntityId);
+static_assert(static_cast<SynchedValueType>(TSynchedValue(std::string{}).index()) == SynchedValueType::String);
 
 class CSynchedStorage : public INetMessageSink
 {
-public:
+protected:
 	using TStorage = std::map<TSynchedKey, TSynchedValue>;
-
 	using TEntityStorageMap = std::map<EntityId, TStorage>;
 
-protected:
 	TStorage m_globalStorage;
 	TEntityStorageMap m_entityStorage;
 
-	IGameFramework *m_pGameFramework = nullptr;
+	IGameFramework* m_pGameFramework = nullptr;
 
 	std::recursive_mutex m_mutex;
 
@@ -42,60 +47,54 @@ protected:
 public:
 	virtual ~CSynchedStorage() = default;
 
-	template<typename ValueType>
-	void SetGlobalValue(TSynchedKey key, const ValueType & value)
+	template<class T>
+	void SetGlobalValue(TSynchedKey key, const T& value)
 	{
 		std::lock_guard lock(m_mutex);
 
-		auto it = m_globalStorage.find(key);
-		if (it == m_globalStorage.end())
+		const auto [it, added] = m_globalStorage.try_emplace(key, value);
+		if (added)
 		{
-			TSynchedValue & newValue = m_globalStorage[key];
-			newValue.Set(value);
-
-			OnGlobalChanged(key, newValue);
+			OnGlobalChanged(key);
 		}
 		else
 		{
-			const ValueType *pStoredValue = it->second.GetPtr<ValueType>();
+			const T* pStoredValue = std::get_if<T>(&it->second);
 			if (!pStoredValue || *pStoredValue != value)
 			{
-				it->second.Set(value);
+				it->second = value;
 
-				OnGlobalChanged(key, it->second);
+				OnGlobalChanged(key);
 			}
 		}
 	}
 
-	template<typename ValueType>
-	void SetEntityValue(EntityId id, TSynchedKey key, const ValueType & value)
+	template<class T>
+	void SetEntityValue(EntityId id, TSynchedKey key, const T& value)
 	{
 		std::lock_guard lock(m_mutex);
 
-		TStorage & storage = m_entityStorage[id];
+		TStorage& storage = m_entityStorage[id];
 
-		auto it = storage.find(key);
-		if (it == storage.end())
+		const auto [it, added] = storage.try_emplace(key, value);
+		if (added)
 		{
-			TSynchedValue & newValue = storage[key];
-			newValue.Set(value);
-
-			OnEntityChanged(id, key, newValue);
+			OnEntityChanged(id, key);
 		}
 		else
 		{
-			const ValueType *pStoredValue = it->second.GetPtr<ValueType>();
+			const T* pStoredValue = std::get_if<T>(&it->second);
 			if (!pStoredValue || *pStoredValue != value)
 			{
-				it->second.Set(value);
+				it->second = value;
 
-				OnEntityChanged(id, key, it->second);
+				OnEntityChanged(id, key);
 			}
 		}
 	}
 
-	template<typename ValueType>
-	bool GetGlobalValue(TSynchedKey key, ValueType & value)
+	template<class T>
+	bool GetGlobalValue(TSynchedKey key, T& value)
 	{
 		std::lock_guard lock(m_mutex);
 
@@ -105,7 +104,7 @@ public:
 			return false;
 		}
 
-		const ValueType *pStoredValue = it->second.GetPtr<ValueType>();
+		const T* pStoredValue = std::get_if<T>(&it->second);
 		if (!pStoredValue)
 		{
 			return false;
@@ -116,7 +115,7 @@ public:
 		return true;
 	}
 
-	bool GetGlobalValue(TSynchedKey key, TSynchedValue & value)
+	bool GetGlobalValue(TSynchedKey key, TSynchedValue& value)
 	{
 		std::lock_guard lock(m_mutex);
 
@@ -131,8 +130,8 @@ public:
 		return true;
 	}
 
-	template<typename ValueType>
-	bool GetEntityValue(EntityId entityId, TSynchedKey key, ValueType & value)
+	template<class T>
+	bool GetEntityValue(EntityId entityId, TSynchedKey key, T& value)
 	{
 		std::lock_guard lock(m_mutex);
 
@@ -148,7 +147,7 @@ public:
 			return false;
 		}
 
-		const ValueType *pStoredValue = it->second.GetPtr<ValueType>();
+		const T* pStoredValue = std::get_if<T>(&it->second);
 		if (!pStoredValue)
 		{
 			return false;
@@ -159,7 +158,7 @@ public:
 		return true;
 	}
 
-	bool GetEntityValue(EntityId entityId, TSynchedKey key, TSynchedValue & value)
+	bool GetEntityValue(EntityId entityId, TSynchedKey key, TSynchedValue& value)
 	{
 		std::lock_guard lock(m_mutex);
 
@@ -180,36 +179,36 @@ public:
 		return true;
 	}
 
-	int GetGlobalValueType(TSynchedKey key)
+	SynchedValueType GetGlobalValueType(TSynchedKey key)
 	{
 		std::lock_guard lock(m_mutex);
 
 		auto it = m_globalStorage.find(key);
 		if (it == m_globalStorage.end())
 		{
-			return eSVT_None;
+			return SynchedValueType::None;
 		}
 
-		return it->second.GetType();
+		return static_cast<SynchedValueType>(it->second.index());
 	}
 
-	int GetEntityValueType(EntityId id, TSynchedKey key)
+	SynchedValueType GetEntityValueType(EntityId id, TSynchedKey key)
 	{
 		std::lock_guard lock(m_mutex);
 
 		auto eit = m_entityStorage.find(id);
 		if (eit == m_entityStorage.end())
 		{
-			return eSVT_None;
+			return SynchedValueType::None;
 		}
 
 		auto it = eit->second.find(key);
 		if (it == eit->second.end())
 		{
-			return eSVT_None;
+			return SynchedValueType::None;
 		}
 
-		return it->second.GetType();
+		return static_cast<SynchedValueType>(it->second.index());
 	}
 
 	void ClearGlobalValue(TSynchedKey key)
@@ -218,8 +217,7 @@ public:
 
 		if (m_globalStorage.erase(key))
 		{
-
-			OnGlobalChanged(key, TSynchedValue{});
+			OnGlobalChanged(key);
 		}
 	}
 
@@ -234,8 +232,7 @@ public:
 
 			if (storage.erase(key))
 			{
-
-				OnEntityChanged(id, key, TSynchedValue{});
+				OnEntityChanged(id, key);
 			}
 
 			if (storage.empty())
@@ -249,15 +246,15 @@ public:
 
 	virtual void Dump();
 
-	void SerializeValue(TSerialize ser, TSynchedKey & key, TSynchedValue & value, int type);
-	void SerializeEntityValue(TSerialize ser, EntityId id, TSynchedKey & key, TSynchedValue & value, int type);
+	void SerializeValue(TSerialize ser, TSynchedKey& key, TSynchedValue& value, SynchedValueType type);
+	void SerializeEntityValue(TSerialize ser, EntityId id, TSynchedKey& key, TSynchedValue& value, SynchedValueType type);
 
 protected:
-	virtual void OnGlobalChanged(TSynchedKey key, const TSynchedValue & value)
+	virtual void OnGlobalChanged(TSynchedKey key)
 	{
 	}
 
-	virtual void OnEntityChanged(EntityId id, TSynchedKey key, const TSynchedValue & value)
+	virtual void OnEntityChanged(EntityId id, TSynchedKey key)
 	{
 	}
 };

--- a/Code/CryMP/Client/Advertising.cpp
+++ b/Code/CryMP/Client/Advertising.cpp
@@ -394,10 +394,7 @@ void CAdManager::FetchAds() {
 		std::string serverToken;
 
 		if (pSSS) {
-			string csServerToken;
-			if (pSSS->GetGlobalValue(ADVERTISING_SERVER_TOKEN, csServerToken)) {
-				serverToken.assign(csServerToken.c_str());
-			}
+			pSSS->GetGlobalValue(ADVERTISING_SERVER_TOKEN, serverToken);
 		}
 
 		auto arr = nlohmann::json::array();
@@ -450,9 +447,7 @@ void CAdManager::FetchAds() {
 	m_collectedRecords.clear();
 
 	if (pSSS) {
-		string csServerResponse;
-		if (pSSS->GetGlobalValue(ADVERTISING_SERVER_RESPONSE, csServerResponse)) {
-			serverResponse.assign(csServerResponse.c_str());
+		if (pSSS->GetGlobalValue(ADVERTISING_SERVER_RESPONSE, serverResponse)) {
 			LoadAds(serverResponse);
 			// when not remote, we assume ads are already bundled inside server pak
 			if (m_state == EAdState::eAS_FetchAds) {
@@ -566,10 +561,7 @@ void CAdManager::CollectViewership(float delta) {
 
 	CSynchedStorage* pSSS = g_pGame->GetSynchedStorage();
 	if (pSSS) {
-		string csServerToken;
-		if (pSSS->GetGlobalValue(ADVERTISING_SERVER_TOKEN, csServerToken)) {
-			serverToken.assign(csServerToken.c_str());
-		}
+		pSSS->GetGlobalValue(ADVERTISING_SERVER_TOKEN, serverToken);
 	}
 
 	if (pPlayer) {

--- a/Code/CryMP/Client/WeatherSystem.cpp
+++ b/Code/CryMP/Client/WeatherSystem.cpp
@@ -11,6 +11,7 @@
 #include "CryCommon/CryRenderer/IRenderer.h"
 #include "CryGame/Game.h"
 #include "CryGame/GameCVars.h"
+#include "Library/StringTools.h"
 
 #include "WeatherSystem.h"
 #include "Cry3DEngine/TimeOfDay.h"
@@ -92,7 +93,7 @@ void CWeatherSystem::Update(float frameTime) {
 		ITimeOfDay* pTOD = gEnv->p3DEngine->GetTimeOfDay();
 		if (pTOD) {
 
-			string todPath;
+			std::string todPath;
 			if (pSSS->GetGlobalValue(WEATHER_TOD_PATH_ID, todPath))
 			{
 				if (todPath != m_lastTodXmlPath)
@@ -114,7 +115,7 @@ void CWeatherSystem::Update(float frameTime) {
 						}
 					}
 
-					pTOD->LoadCustomSettings(todPath, blendDuration);
+					pTOD->LoadCustomSettings(todPath.c_str(), blendDuration);
 
 					m_lastTodXmlPath = todPath;
 				}
@@ -122,7 +123,7 @@ void CWeatherSystem::Update(float frameTime) {
 
 			int count = pTOD->GetVariableCount();
 			for (int i = 0; i < count; i++) {
-				string value;
+				std::string value;
 				auto existing = m_activeValues.find(WEATHER_ENV_NAMESPACE + i);
 				if (pSSS->GetGlobalValue(WEATHER_ENV_NAMESPACE + i, value) && value.length() > 0) {
 					if (existing == m_activeValues.end() || existing->second != value) {
@@ -154,7 +155,7 @@ void CWeatherSystem::Update(float frameTime) {
 			}
 			for (int i = WEATHER_ENABLED + 1; i < WEATHER_VAR_COUNT; i++) {
 				float f3[3];
-				string value;
+				std::string value;
 				auto existing = m_activeValues.find(WEATHER_NAMESPACE + i);
 				pSSS->GetGlobalValue(WEATHER_NAMESPACE + i, value);
 				if (existing == m_activeValues.end() || existing->second != value) {
@@ -837,7 +838,7 @@ void CWeatherSystem::PostUpdate()
 			progress = std::clamp(t / d, 0.0f, 1.0f);
 		}
 
-		string xml = pTOD->GetActiveCustomTodFile();
+		std::string_view xml = StringTools::SafeView(pTOD->GetActiveCustomTodFile());
 		if (xml.empty())
 		{
 			xml = m_lastTodXmlPath;
@@ -900,15 +901,13 @@ std::string_view CWeatherSystem::GetTodXmlName(std::string_view path) const
 	return path;
 }
 
-void CWeatherSystem::UpdateTodXmlNameCache(const string& xmlPath)
+void CWeatherSystem::UpdateTodXmlNameCache(std::string_view xmlPath)
 {
-	std::string path(xmlPath.c_str());
-
-	if (path == m_cachedTodXmlPath)
+	if (xmlPath == m_cachedTodXmlPath)
 	{
 		return;
 	}
 
-	m_cachedTodXmlPath = std::move(path);
+	m_cachedTodXmlPath = xmlPath;
 	m_cachedTodXmlName = this->GetTodXmlName(m_cachedTodXmlPath);
 }

--- a/Code/CryMP/Client/WeatherSystem.h
+++ b/Code/CryMP/Client/WeatherSystem.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include <array>
 #include <map>
 #include <optional>
@@ -33,12 +34,12 @@ class CWeatherSystem {
 	};
 
 	bool                          m_enabled = false;
-	string                        m_lastTodXmlPath;
+	std::string                   m_lastTodXmlPath;
 	std::map<int, float[3]>       m_originalWeatherValues;
 	std::optional<Vec3>           m_originalWind;
 	std::map<int, IStatInstGroup> m_originalGroups;
 
-	std::map<int, string>                                 m_activeValues;
+	std::map<int, std::string>                            m_activeValues;
 	std::set<std::string>                                 m_activeEffects;
 	std::optional<unsigned>                               m_activeMask;
 	std::map<std::string, std::vector<IParticleEmitter*>> m_activeEmitters;
@@ -98,6 +99,6 @@ private:
 	std::string m_cachedTodXmlPath;
 	std::string m_cachedTodXmlName;
 
-	void UpdateTodXmlNameCache(const string& xmlPath);
-	std::string_view GetTodXmlName(std::string_view path) const;
+	void UpdateTodXmlNameCache(std::string_view xmlPath);
+	std::string_view GetTodXmlName(std::string_view xmlPath) const;
 };


### PR DESCRIPTION
There is a data race bug in SynchedStorage. The root cause is CryString. It uses ref-counting instead of deep copies and cannot be shared between threads. `CSynchedStorage::SerializeValue` and `CSynchedStorage::SerializeEntityValue` are called from network thread. This causes CryString being copied between network thread and main thread, which sporadically triggers the bug.

To fix the bug, CryString in SynchedStorage is completely replaced with `std::string`. This allowed replacing CryString with `std::string` in other places as well. Additionally, `CConfigurableVariant` in SynchedStorage is replaced with modern `std::variant`.