### PR TITLE
Allow importing custom weapons using server PAK technology

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -845,6 +845,11 @@ if(MSVC AND CRYMP_ASAN)
     target_link_options(Base PUBLIC
         /fsanitize=address
     )
+
+	target_compile_definitions(Base PUBLIC
+        _DISABLE_VECTOR_ANNOTATION
+        _DISABLE_STRING_ANNOTATION
+    )
 endif()
 
 target_compile_options(Base PUBLIC /W4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -562,6 +562,8 @@ add_library(Base OBJECT
 	Code/CryMP/Common/Executor.h
 	Code/CryMP/Common/ServerPAK.cpp
 	Code/CryMP/Common/ServerPAK.h
+	Code/CryMP/Common/Utilities.cpp
+	Code/CryMP/Common/Utilities.h
 	Code/CryMP/Common/GSMasterHook.cpp
 	Code/CryMP/Common/GSMasterHook.h
 	Code/CryMP/Common/HTTP.cpp

--- a/Code/CryAction/ItemSystem.cpp
+++ b/Code/CryAction/ItemSystem.cpp
@@ -1100,9 +1100,16 @@ void ItemSystem::ScanXml(XmlNodeRef& root, const char* xmlFile)
 			entityClass.sScriptFile = defaultScript;
 		}
 
-		if (!m_reloading)
+		IGameObjectSystem* pGOS = m_pGameFramework->GetIGameObjectSystem();
+		if (m_reloading)
 		{
-			m_pGameFramework->GetIGameObjectSystem()->RegisterExtension(itemName, pCreator, &entityClass);
+			if (!m_extensions.contains(itemName)) {
+				pGOS->RegisterExtension(itemName, pCreator, &entityClass);
+				m_extensions.insert(itemName);
+			}
+		} else {
+			pGOS->RegisterExtension(itemName, pCreator, &entityClass);
+			m_extensions.insert(itemName);
 		}
 	}
 

--- a/Code/CryAction/ItemSystem.h
+++ b/Code/CryAction/ItemSystem.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <string_view>
 #include <vector>
+#include <set>
 
 #include "CryCommon/CryAction/IGameFramework.h"
 #include "CryCommon/CryAction/IItemSystem.h"
@@ -52,6 +53,8 @@ class ItemSystem final : public ILevelSystemListener, public IItemSystem
 	std::vector<EntityId> m_garbage;
 	std::vector<IItemSystemListener*> m_listeners;
 	std::vector<std::string> m_folders;
+
+	std::set<std::string> m_extensions;
 
 	std::unique_ptr<EquipmentManager> m_pEquipmentManager;
 

--- a/Code/CryMP/Common/ServerPAK.cpp
+++ b/Code/CryMP/Common/ServerPAK.cpp
@@ -11,6 +11,7 @@
 #include "CrySystem/CryPak.h"
 
 #include "ServerPAK.h"
+#include "Utilities.h"
 
 ServerPAK::ServerPAK()
 {
@@ -78,6 +79,7 @@ void ServerPAK::ResetSubSystems()
 	IGameFramework* pGameFrameWork = gEnv->pGame->GetIGameFramework();
 
 	//Reset a bunch of subsystems
+	ResetGameObjectSystem();
 	gEnv->p3DEngine->ResetPostEffects();
 	gEnv->p3DEngine->ResetParticlesAndDecals();
 	pGameFrameWork->ResetBrokenGameObjects();

--- a/Code/CryMP/Common/Utilities.cpp
+++ b/Code/CryMP/Common/Utilities.cpp
@@ -47,8 +47,8 @@ void ResetGameObjectSystem() {
 	// the network system won't recognize it and it will disconnect the player on protocol error.
 	// Therefore we need to reconstruct the database like this, since this is internal function of CE SDK class
 	// and it's not exposed in the public SDK.
-	IGameObjectSystem* pGOS = static_cast<IGameObjectSystem*>(gEnv->pGame->GetIGameFramework()->GetIGameObjectSystem());
-	if (XmlNodeRef schedParams = gEnv->pSystem->LoadXmlFile("Game/Scripts/Network/EntityScheduler.xml"))
+	IGameObjectSystem* pGOS = gEnv->pGame->GetIGameFramework()->GetIGameObjectSystem();
+	if (XmlNodeRef schedParams = gEnv->pSystem->LoadXmlFile("Scripts/Network/EntityScheduler.xml"))
 	{
 		uint32 defaultPolicy = 0;
 
@@ -99,7 +99,7 @@ void ResetGameObjectSystem() {
 	// by server/client PAK
 
 	IEntityClassRegistry* pClassRegistry = gEnv->pEntitySystem->GetClassRegistry();
-	pClassRegistry->LoadClasses("LoadClasses", true);
+	pClassRegistry->LoadClasses("Entities", true);
 
 	// Merely calling Reload doesn't create new classes in the Network system, that's why
 	// Scan(...) must be called instead

--- a/Code/CryMP/Common/Utilities.cpp
+++ b/Code/CryMP/Common/Utilities.cpp
@@ -108,7 +108,5 @@ void ResetGameObjectSystem() {
 		);
 	*pDispatchSafety = false;
 #endif
-	// Merely calling Reload doesn't create new classes in the Network system, that's why
-	// Scan(...) must be called instead
 	gEnv->pGame->GetIGameFramework()->GetIItemSystem()->Reload();
 }

--- a/Code/CryMP/Common/Utilities.cpp
+++ b/Code/CryMP/Common/Utilities.cpp
@@ -5,6 +5,8 @@
 #include "CryGame/Game.h"
 #include "CrySystem/CryPak.h"
 
+extern std::uintptr_t CRYACTION_BASE;
+
 static bool StringToKey(const char* s, uint32& key)
 {
 	const size_t len = strlen(s);
@@ -28,14 +30,13 @@ struct SEntitySchedulingProfiles
 };
 
 void ResetGameObjectSystem() {
-
 #ifdef BUILD_64BIT
 	constexpr size_t kSchedulingParamsOffset = 0xD8;
-	constexpr uintptr_t kMapOperator = 0x306B3120;
+	uintptr_t kMapOperator = CRYACTION_BASE + 0x1B3120;
 	typedef SEntitySchedulingProfiles* (__fastcall* PFNEMPLACE)(void* map, string* key);
 #else
 	constexpr size_t kSchedulingParamsOffset = 0x6C;
-	constexpr uintptr_t kMapOperator = 0x3062EE00;
+	uintptr_t kMapOperator = CRYACTION_BASE + 0x12EE00;
 	typedef SEntitySchedulingProfiles* (__fastcall* PFNEMPLACE)(void* map, void *dummyEdx, string* key);
 #endif
 

--- a/Code/CryMP/Common/Utilities.cpp
+++ b/Code/CryMP/Common/Utilities.cpp
@@ -29,19 +29,21 @@ struct SEntitySchedulingProfiles
 	uint32 owned;
 };
 
-void ResetGameObjectSystem() {
+struct SchedulingParamsMap
+{
+	SEntitySchedulingProfiles& operator[](const string& key)
+	{
 #ifdef BUILD_64BIT
-	constexpr size_t kSchedulingParamsOffset = 0xD8;
-	uintptr_t kMapOperator = CRYACTION_BASE + 0x1B3120;
-	typedef SEntitySchedulingProfiles* (__fastcall* PFNEMPLACE)(void* map, string* key);
+		std::uintptr_t func = CRYACTION_BASE + 0x1B3120;
 #else
-	constexpr size_t kSchedulingParamsOffset = 0x6C;
-	uintptr_t kMapOperator = CRYACTION_BASE + 0x12EE00;
-	typedef SEntitySchedulingProfiles* (__fastcall* PFNEMPLACE)(void* map, void *dummyEdx, string* key);
+		std::uintptr_t func = CRYACTION_BASE + 0x12EE00;
 #endif
 
-	PFNEMPLACE Emplace = (PFNEMPLACE)kMapOperator;
+		return (this->*reinterpret_cast<decltype(&SchedulingParamsMap::operator[])&>(func))(key);
+	}
+};
 
+void ResetGameObjectSystem() {
 	// By default game initializes this only once, it contains information on how to schedule
 	// entity classes on network. Now, the issue is if there are new classes in the server/client PAK
 	// the network system won't recognize it and it will disconnect the player on protocol error.
@@ -76,22 +78,13 @@ void ResetGameObjectSystem() {
 			if (node->haveAttr("own"))
 				StringToKey(node->getAttr("own"), p.owned);
 
-			// CE2 SDK uses MSVC 2005, since we are building with at least MSVC 2022, calling std::map::emplace
-			// would crash on ABI differences.
-			// Instead we call existing MSVC 2005 API inside CE2 SDK to emplace the object
-			//  original code: m_schedulingParams[name] = p;
-			void* m_schedulingParams = reinterpret_cast<void*>(
-				reinterpret_cast<uintptr_t>(pGOS) + kSchedulingParamsOffset
-			);
+			SchedulingParamsMap& m_schedulingParams =
 #ifdef BUILD_64BIT
-			auto value = Emplace(m_schedulingParams, &name);
-			*value = p;
+				*reinterpret_cast<SchedulingParamsMap*>(reinterpret_cast<std::uintptr_t>(pGOS) + 0xD8);
 #else
-			// We need to fill EDX with a dummy value to force &name to be pushed on stack
-			// since this is a thiscall masked as a fastcall.
-			auto value = Emplace(m_schedulingParams, NULL, &name);
-			*value = p;
+				*reinterpret_cast<SchedulingParamsMap*>(reinterpret_cast<std::uintptr_t>(pGOS) + 0x6C);
 #endif
+			m_schedulingParams[name] = p;
 		}
 	}
 

--- a/Code/CryMP/Common/Utilities.cpp
+++ b/Code/CryMP/Common/Utilities.cpp
@@ -94,7 +94,21 @@ void ResetGameObjectSystem() {
 	IEntityClassRegistry* pClassRegistry = gEnv->pEntitySystem->GetClassRegistry();
 	pClassRegistry->LoadClasses("Entities", true);
 
+	// Now we must reconstruct the protocol definition, to do so we reset the safety state
+	// which will force CryEngine to rebuild the extension ID tables for network sinks
+	// before connecting to the server
+#ifdef BUILD_64BIT
+	bool* pDispatchSafety = reinterpret_cast<bool*>(
+		reinterpret_cast<uintptr_t>(pGOS) + 0x50
+	);
+	*pDispatchSafety = false;
+#else
+	bool* pDispatchSafety = reinterpret_cast<bool*>(
+		reinterpret_cast<uintptr_t>(pGOS) + 0x28
+		);
+	*pDispatchSafety = false;
+#endif
 	// Merely calling Reload doesn't create new classes in the Network system, that's why
 	// Scan(...) must be called instead
-	gEnv->pGame->GetIGameFramework()->GetIItemSystem()->Scan("Scripts/Entities/Items/XML");
+	gEnv->pGame->GetIGameFramework()->GetIItemSystem()->Reload();
 }

--- a/Code/CryMP/Common/Utilities.cpp
+++ b/Code/CryMP/Common/Utilities.cpp
@@ -1,0 +1,106 @@
+#include "Utilities.h"
+
+#include "CryCommon/CryEntitySystem/IEntitySystem.h"
+#include "CryAction/ItemSystem.h"
+#include "CryGame/Game.h"
+#include "CrySystem/CryPak.h"
+
+static bool StringToKey(const char* s, uint32& key)
+{
+	const size_t len = strlen(s);
+	if (len > 4)
+		return false;
+
+	key = 0;
+	for (size_t i = 0; i < len; i++)
+	{
+		key <<= 8;
+		key |= uint8(s[i]);
+	}
+
+	return true;
+}
+
+struct SEntitySchedulingProfiles
+{
+	uint32 normal;
+	uint32 owned;
+};
+
+void ResetGameObjectSystem() {
+
+#ifdef BUILD_64BIT
+	constexpr size_t kSchedulingParamsOffset = 0xD8;
+	constexpr uintptr_t kMapOperator = 0x306B3120;
+	typedef SEntitySchedulingProfiles* (__fastcall* PFNEMPLACE)(void* map, string* key);
+#else
+	constexpr size_t kSchedulingParamsOffset = 0x6C;
+	constexpr uintptr_t kMapOperator = 0x3062EE00;
+	typedef SEntitySchedulingProfiles* (__fastcall* PFNEMPLACE)(void* map, void *dummyEdx, string* key);
+#endif
+
+	PFNEMPLACE Emplace = (PFNEMPLACE)kMapOperator;
+
+	// By default game initializes this only once, it contains information on how to schedule
+	// entity classes on network. Now, the issue is if there are new classes in the server/client PAK
+	// the network system won't recognize it and it will disconnect the player on protocol error.
+	// Therefore we need to reconstruct the database like this, since this is internal function of CE SDK class
+	// and it's not exposed in the public SDK.
+	IGameObjectSystem* pGOS = static_cast<IGameObjectSystem*>(gEnv->pGame->GetIGameFramework()->GetIGameObjectSystem());
+	if (XmlNodeRef schedParams = gEnv->pSystem->LoadXmlFile("Game/Scripts/Network/EntityScheduler.xml"))
+	{
+		uint32 defaultPolicy = 0;
+
+		if (XmlNodeRef defpol = schedParams->findChild("Default"))
+		{
+			if (!StringToKey(defpol->getAttr("policy"), defaultPolicy))
+			{
+				return;
+			}
+		}
+
+		for (int i = 0; i < schedParams->getChildCount(); i++)
+		{
+			XmlNodeRef node = schedParams->getChild(i);
+			if (0 != strcmp(node->getTag(), "Class"))
+				continue;
+
+			string name = node->getAttr("name");
+
+			SEntitySchedulingProfiles p;
+			p.normal = defaultPolicy;
+			if (node->haveAttr("policy"))
+				StringToKey(node->getAttr("policy"), p.normal);
+			p.owned = p.normal;
+			if (node->haveAttr("own"))
+				StringToKey(node->getAttr("own"), p.owned);
+
+			// CE2 SDK uses MSVC 2005, since we are building with at least MSVC 2022, calling std::map::emplace
+			// would crash on ABI differences.
+			// Instead we call existing MSVC 2005 API inside CE2 SDK to emplace the object
+			//  original code: m_schedulingParams[name] = p;
+			void* m_schedulingParams = reinterpret_cast<void*>(
+				reinterpret_cast<uintptr_t>(pGOS) + kSchedulingParamsOffset
+			);
+#ifdef BUILD_64BIT
+			auto value = Emplace(m_schedulingParams, &name);
+			*value = p;
+#else
+			// We need to fill EDX with a dummy value to force &name to be pushed on stack
+			// since this is a thiscall masked as a fastcall.
+			auto value = Emplace(m_schedulingParams, NULL, &name);
+			*value = p;
+#endif
+		}
+	}
+
+	// Reset entity system and item system, so they recognize possibly new classes imported
+	// by server/client PAK
+
+	IEntityClassRegistry* pClassRegistry = gEnv->pEntitySystem->GetClassRegistry();
+	pClassRegistry->LoadClasses("LoadClasses", true);
+
+	// Merely calling Reload doesn't create new classes in the Network system, that's why
+	// Scan(...) must be called instead
+	gEnv->pGame->GetIGameFramework()->GetIItemSystem()->Scan("Scripts/Entities/Items/XML");
+}

--- a/Code/CryMP/Common/Utilities.h
+++ b/Code/CryMP/Common/Utilities.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void ResetGameObjectSystem();

--- a/Code/CryMP/Server/Server.cpp
+++ b/Code/CryMP/Server/Server.cpp
@@ -19,6 +19,8 @@
 #include "CryMP/Server/SSM.h"
 #include "CryMP/Server/SafeWriting/SafeWriting.h"
 
+#include "CryMP/Common/Utilities.h"
+
 Server::Server()
 {
 }
@@ -36,10 +38,11 @@ void Server::Init(IGameFramework* pGameFramework)
 
 	pGameFramework->RegisterListener(this, "crymp-server", FRAMEWORKLISTENERPRIORITY_DEFAULT);
 
-
+	bool hasPak = false;
 	const std::string serverPak(WinAPI::CmdLine::GetArgValue("-pak"));
 	if (!serverPak.empty()) {
         const bool success = CryPak::GetInstance().LoadServerPak(serverPak);
+		hasPak = true;
         CryLogAlways("$6[CryMP] Loading server pak '%s' %s", serverPak.c_str(), success ? "succeeded" : "failed");
 	}
 
@@ -47,6 +50,10 @@ void Server::Init(IGameFramework* pGameFramework)
 	// mods are not supported
 	this->pGame = new CGame();
 	this->pGame->Init(pGameFramework);
+
+	if (hasPak) {
+		ResetGameObjectSystem();
+	}
 
 	if (ICVar* maxPlayers = gEnv->pConsole->GetCVar("sv_maxplayers")) {
 		// this overrides max 32 players cap


### PR DESCRIPTION
This PR makes it possible to import new weapons into the game through the server PAK.

This wasn't previously possible because of network errors that stemmed from lack of new entity class registration within the network and game object contexts.