### PR TITLE
Add missile approach sound

### DIFF
--- a/Code/CryCommon/CrySoundSystem/ISound.h
+++ b/Code/CryCommon/CrySoundSystem/ISound.h
@@ -129,6 +129,8 @@ typedef uint32	tSoundID;
 #define FLAG_SOUND_SQUELCH							0x04000000  // this sound has a radio squelch parameter
 #define FLAG_SOUND_DOPPLER_PARAM				0x08000000  // this sound has a doppler parameter
 #define FLAG_SOUND_MOVIE								0x10000000  // this is a movie sound
+//CryMP
+#define FLAG_SOUND_NO_3D_VELOCITY    0x20000000  //CryMP: don't pass source velocity
 
 
 //#define FLAG_SOUND_DEFAULT_3D (FLAG_SOUND_3D | FLAG_SOUND_RADIUS | FLAG_SOUND_CULLING | FLAG_SOUND_OBSTRUCTION )

--- a/Code/CryGame/GameCVars.cpp
+++ b/Code/CryGame/GameCVars.cpp
@@ -724,6 +724,7 @@ void SCVars::InitCVars(IConsole* pConsole)
 	pConsole->Register("mp_abandonTime", &mp_abandonTime, 10.f, VF_NOT_NET_SYNCED/*VF_CHEAT*/, "Time in seconds after which vehicles explode");
 	pConsole->Register("mp_explosiveRemovalTime", &mp_explosiveRemovalTime, 30.f, VF_NOT_NET_SYNCED/*VF_CHEAT*/, "Time in seconds for explosive removal after death");
 	pConsole->Register("mp_explosion_mfx", &mp_explosion_mfx, 1, VF_NOT_NET_SYNCED, "Enable mfx via ClExplosion rmi for server controlled missiles");
+	pConsole->Register("mp_missileApproachSound", &mp_missileApproachSound, 1, VF_NOT_NET_SYNCED, "Enable missile approach sound");
 
 	pConsole->Register("cl_hud_chat", &cl_hud_chat, 1, VF_NOT_NET_SYNCED, "Shows / hides chat");
 	pConsole->Register("ads", &ads, 1, VF_NOT_NET_SYNCED, "Enable or disable (100h+) ads");

--- a/Code/CryGame/GameCVars.h
+++ b/Code/CryGame/GameCVars.h
@@ -487,6 +487,7 @@ struct SCVars
 	int			mp_fpsLimit;
 	float		mp_soundSpeed;
 	float       mp_cloakVisibility;
+	int         mp_missileApproachSound;
 	ICVar*      mp_language;
 
 	int			mp_chat;

--- a/Code/CryGame/Items/Weapons/AmmoParams.cpp
+++ b/Code/CryGame/Items/Weapons/AmmoParams.cpp
@@ -152,6 +152,23 @@ SWhizParams::SWhizParams(const IItemParamsNode* whiz)
 	reader.Read("speed", speed);
 }
 
+SMissileApproachParams::SMissileApproachParams(const IItemParamsNode* missileApproach)
+	: sound(0)
+	, prediction(2.0f)
+	, passRadius(150.0f)
+	, distanceMultiplier(2.5f)
+{
+	CItemParamReader reader(missileApproach);
+
+	reader.Read("sound", sound);
+	if (sound && !sound[0])
+		sound = 0;
+
+	reader.Read("prediction", prediction);
+	reader.Read("pass_radius", passRadius);
+	reader.Read("distance_multiplier", distanceMultiplier);
+}
+
 SAmmoParams::SAmmoParams(const IItemParamsNode* pItemParams_, const IEntityClass* pEntityClass_)
 	: flags(0)
 	, serverSpawn(0)
@@ -179,6 +196,7 @@ SAmmoParams::SAmmoParams(const IItemParamsNode* pItemParams_, const IEntityClass
 	, pExplosion(0)
 	, pFlashbang(0)
 	, pWhiz(0)
+	, pMissileApproach(0)
 	, pRicochet(0)
 	, pTrail(0)
 	, pTrailUnderWater(0)
@@ -196,6 +214,7 @@ SAmmoParams::~SAmmoParams()
 	delete pExplosion;
 	delete pFlashbang;
 	delete pWhiz;
+	delete pMissileApproach;
 	delete pRicochet;
 	delete pTrail;
 	delete pTrailUnderWater;
@@ -223,7 +242,7 @@ void SAmmoParams::Init(const IItemParamsNode* pItemParams_, const IEntityClass* 
 	LoadCollision();
 	LoadExplosion();
 	LoadFlashbang();
-	LoadTrailsAndWhizzes();
+	LoadSoundParams();
 }
 
 int SAmmoParams::GetMemorySize() const
@@ -439,7 +458,7 @@ void SAmmoParams::LoadFlashbang()
 		pFlashbang = new SFlashbangParams(flashbang);
 }
 
-void SAmmoParams::LoadTrailsAndWhizzes()
+void SAmmoParams::LoadSoundParams()
 {
 	const IItemParamsNode* whiz = pItemParams->GetChild("whiz");
 	if (whiz)
@@ -482,6 +501,18 @@ void SAmmoParams::LoadTrailsAndWhizzes()
 		{
 			delete pTrailUnderWater;
 			pTrailUnderWater = 0;
+		}
+	}
+
+	const IItemParamsNode* missileApproach = pItemParams->GetChild("missile_approach");
+	if (missileApproach)
+	{
+		pMissileApproach = new SMissileApproachParams(missileApproach);
+
+		if (!pMissileApproach->sound)
+		{
+			delete pMissileApproach;
+			pMissileApproach = 0;
 		}
 	}
 }

--- a/Code/CryGame/Items/Weapons/AmmoParams.h
+++ b/Code/CryGame/Items/Weapons/AmmoParams.h
@@ -83,6 +83,16 @@ struct SWhizParams
 	SWhizParams(const IItemParamsNode* whiz);
 };
 
+struct SMissileApproachParams
+{
+	const char* sound;
+	float prediction;
+	float passRadius;
+	float distanceMultiplier;
+
+	SMissileApproachParams(const IItemParamsNode* missileApproach);
+};
+
 
 // this structure holds cached XML attributes for fast acccess
 struct SAmmoParams
@@ -124,6 +134,7 @@ struct SAmmoParams
 	SExplosionParams*			pExplosion;
 	SFlashbangParams*			pFlashbang;
 	SWhizParams*					pWhiz;
+	SMissileApproachParams*         pMissileApproach;
 	SWhizParams*					pRicochet;
 	STrailParams*					pTrail;
 	STrailParams*					pTrailUnderWater;
@@ -146,7 +157,7 @@ private:
 	void LoadCollision();
 	void LoadExplosion();
 	void LoadFlashbang();
-	void LoadTrailsAndWhizzes();
+	void LoadSoundParams();
 };
 
 #endif//__AMMOPARAMS_H__

--- a/Code/CryGame/Items/Weapons/Projectile.cpp
+++ b/Code/CryGame/Items/Weapons/Projectile.cpp
@@ -401,7 +401,8 @@ void CProjectile::Update(SEntityUpdateContext& ctx, int updateSlot)
 
 	ScaledEffect(m_pAmmoParams->pScaledEffect);
 
-	UpdateWhiz();
+	UpdateWhiz(); 
+	UpdateMissileApproach(ctx.fFrameTime);
 
 	if (m_trailSoundId == INVALID_SOUNDID)
 		TrailSound(true);
@@ -1519,3 +1520,126 @@ void CProjectile::InitWithAI()
 	GetGameObject()->SetAIActivation(eGOAIAM_Always);
 }
 
+//------------------------------------------------------------------------
+void CProjectile::UpdateMissileApproach(const float frameTime)
+{
+	if (!gEnv->bClient || !g_pGameCVars->mp_missileApproachSound || !m_pAmmoParams->pMissileApproach)
+		return;
+
+	if (m_missileApproachCooldown > 0.0f)
+	{
+		m_missileApproachCooldown -= frameTime;
+		return;
+	}
+
+	if (!g_pGame->GetIGameFramework()->GetClientActor() || !m_pPhysicalEntity)
+		return;
+
+	pe_status_dynamics dynamics;
+	if (!m_pPhysicalEntity->GetStatus(&dynamics))
+		return;
+
+	const Vec3 velocity = dynamics.v;
+	const float speedSq = velocity.GetLengthSquared();
+
+	if (speedSq < 1.0f)
+		return;
+
+	const float speed = sqrt_tpl(speedSq);
+
+	const Vec3 listenerPos = gEnv->pSystem->GetViewCamera().GetPosition();
+	const Vec3 missilePos = GetEntity()->GetWorldPos();
+	const Vec3 toListener = listenerPos - missilePos;
+
+	const float distanceSq = toListener.GetLengthSquared();
+
+	//CryMP: Don't trigger right after firing
+	const float armDistance = 30.0f;
+
+	if (!m_missileApproachArmed)
+	{
+		if (distanceSq < armDistance * armDistance)
+			return;
+
+		m_missileApproachArmed = true;
+	}
+
+	const SMissileApproachParams* pParams = m_pAmmoParams->pMissileApproach;
+	const float predictionTime = pParams->prediction;
+
+	//CryMP: Detect fast missiles further away
+	const float triggerRange = speed * predictionTime;
+
+	if (distanceSq > triggerRange * triggerRange)
+		return;
+
+	const float distance = sqrt_tpl(distanceSq);
+
+	if (distance <= 0.0f)
+		return;
+
+	const float approachDot = toListener.Dot(velocity);
+
+	if (approachDot <= 0.0f)
+		return;
+
+	const float directionDot = approachDot / (distance * speed);
+	const float minimumDirectionDot = 0.5f;
+
+	if (directionDot < minimumDirectionDot)
+		return;
+
+	const float closestTime = approachDot / speedSq;
+
+	if (closestTime <= 0.0f || closestTime > predictionTime)
+		return;
+
+	const Vec3 closestOffset = toListener - velocity * closestTime;
+	const float passRadius = pParams->passRadius;
+
+	if (closestOffset.GetLengthSquared() > passRadius * passRadius)
+		return;
+
+	MissileApproachSound();
+
+	m_missileApproachCooldown = 3.5f;
+}
+
+//------------------------------------------------------------------------
+void CProjectile::MissileApproachSound()
+{
+	IEntitySoundProxy* pSoundProxy = GetSoundProxy();
+	if (!pSoundProxy)
+		return;
+
+	const SMissileApproachParams* params = m_pAmmoParams->pMissileApproach;
+	const char* soundName = params->sound;
+	const float baseDistanceMultiplier = params->distanceMultiplier;
+
+	ISound* pSound = gEnv->pSoundSystem->CreateSound(
+		soundName,
+		FLAG_SOUND_DEFAULT_3D | FLAG_SOUND_NO_3D_VELOCITY); //CryMP: Disable Doppler effect
+
+	if (!pSound)
+		return;
+
+	pSound->SetSemantic(eSoundSemantic_Projectile);
+
+	const Vec3 listenerPos = gEnv->pSystem->GetViewCamera().GetPosition();
+	const float currentDistance = (GetEntity()->GetWorldPos() - listenerPos).GetLength();
+
+	const float originalMaxDistance = pSound->GetMaxDistance();
+
+	float distanceMultiplier = baseDistanceMultiplier;
+
+	//CryMP: Increase the sound range if a fast missile triggers further away
+	if (originalMaxDistance > 0.0f)
+	{
+		const float requiredMultiplier = (currentDistance + 25.0f) / originalMaxDistance;
+		distanceMultiplier = max(distanceMultiplier, requiredMultiplier);
+	}
+
+	pSound->SetDistanceMultiplier(distanceMultiplier);
+
+	pSoundProxy->PlaySound(pSound, Vec3(), FORWARD_DIRECTION, 1.0f, false);
+}

--- a/Code/CryGame/Items/Weapons/Projectile.h
+++ b/Code/CryGame/Items/Weapons/Projectile.h
@@ -156,6 +156,9 @@ protected:
 	void DestroyObstructObject();
 
 	IEntitySoundProxy *GetSoundProxy();
+	void UpdateMissileApproach(const float frameTime);
+	void MissileApproachSound();
+
 	template<typename T> T GetParam(const char *name, T &def)
 	{
 		T v(def);
@@ -212,6 +215,10 @@ protected:
 	float m_spawnTime = 0.0f;
 	bool m_netUpdateReceived = false;
 	bool m_ghost = false;
+
+	bool m_missileApproachArmed = false;
+	float m_missileApproachCooldown = 0.0f;
+
 };
 
 #endif

--- a/Code/CrySoundSystem/PlatformSoundFmodEx400.cpp
+++ b/Code/CrySoundSystem/PlatformSoundFmodEx400.cpp
@@ -147,8 +147,15 @@ bool CPlatformSoundFmodEx400::Set3DPosition(Vec3* pvPosition, Vec3* pvVelocity, 
 			return false;
 		}
 
-		m_ExResult =
-		    m_pExChannel->set3DAttributes((pvPosition ? &vExPos : NULL), (pvPosition ? &vExVel : NULL));
+		//CryMP: This must be a bug?
+		//m_ExResult =
+		//    m_pExChannel->set3DAttributes((pvPosition ? &vExPos : NULL), (pvPosition ? &vExVel : NULL));
+
+		//CryMP: Fix
+		m_pExChannel->set3DAttributes(
+			pvPosition ? &vExPos : nullptr,
+			pvVelocity ? &vExVel : nullptr);
+
 		if (m_ExResult != FMOD_OK)
 		{
 			FmodErrorOutput("set 3d channel position failed! ", ILog::eWarning);

--- a/Code/CrySoundSystem/Sound.cpp
+++ b/Code/CrySoundSystem/Sound.cpp
@@ -667,7 +667,7 @@ void CSound::Update()
 
 		UpdatePositionAndVelocity();
 
-		if (m_nFlags & FLAG_SOUND_DOPPLER_PARAM || true)
+		//if (m_nFlags & FLAG_SOUND_DOPPLER_PARAM || true)  //CryMP: Always called
 		{
 			Vec3 vRelativeVelocity = pListener->GetVelocity() - m_vSpeed;
 			float fDoppler = vRelativeVelocity.GetLength() * 3.6f; // Kmh
@@ -2131,22 +2131,27 @@ void CSound::UpdatePositionAndVelocity()
 
 	if (m_nFlags & FLAG_SOUND_SELFMOVING)
 	{
-		float fTimeDelta = gEnv->pTimer->GetFrameTime();
-		Vec3 vNewPos = (m_vPosition + m_vDirection * fTimeDelta);
-		SetPosition(vNewPos);
+		const float timeDelta = gEnv->pTimer->GetFrameTime();
+		const Vec3 newPos = m_vPosition + m_vDirection * timeDelta;
+		SetPosition(newPos);
 	}
 
 	if (m_nFlags & FLAG_SOUND_RELATIVE)
 		SetPosition(m_vPosition);
 
 	if (IsActive() && (m_nFlags & FLAG_SOUND_3D) && m_pPlatformSound)
-	// if (m_nFlags & FLAG_SOUND_RELATIVE)
-	//{
-	//	m_pPlatformSound->Set3DPosition(&m_vPosition, &m_vSpeed);
-	// }
-	// else
 	{
-		m_pPlatformSound->Set3DPosition(&m_vPlaybackPos, &m_vSpeed, m_vDirection.IsZero() ? 0 : &m_vDirection);
+		Vec3 velocity = m_vSpeed;
+
+		//CryMP: Some sounds already contain their own movement/Doppler effect.
+		//Keep updating the 3D position, but don't pass source velocity to FMOD.
+		if (m_nFlags & FLAG_SOUND_NO_3D_VELOCITY)
+			velocity = {};
+
+		m_pPlatformSound->Set3DPosition(
+			&m_vPlaybackPos,
+			&velocity,
+			m_vDirection.IsZero() ? nullptr : &m_vDirection);
 	}
 }
 
@@ -2341,46 +2346,49 @@ void CSound::SetDirection(const Vec3& vDir)
 {
 	m_vDirection = vDir;
 }
+
 float CSound::GetRatioByDistance(const float fDistance)
 {
 	assert(m_pPlatformSound);
 
 	// Sounds without a radius always play at full volume
 	if (!(m_nFlags & FLAG_SOUND_RADIUS) || !m_pPlatformSound)
+	{
 		return 1.0f;
+	}
 
 	// Events attenuate using their distance parameter
 	if (m_nFlags & FLAG_SOUND_EVENT)
 	{
+		const float eventDistance = fDistance / m_RadiusSpecs.fDistanceMultiplier;
+
 		if (m_pPlatformSound->GetSoundHandle())
 		{
-			ptParamF32 fParam(fDistance / m_RadiusSpecs.fDistanceMultiplier);
+			ptParamF32 fParam(eventDistance);
 			m_pPlatformSound->SetParamByType(pspDISTANCE, &fParam);
 		}
 
 		if (m_nFlags & FLAG_SOUND_SPREAD)
 		{
-			ptParamF32 fParam((fDistance / m_RadiusSpecs.fDistanceMultiplier) / m_RadiusSpecs.fMaxRadius);
+			ptParamF32 fParam(eventDistance / m_RadiusSpecs.fMaxRadius);
+
 			m_pPlatformSound->SetParamByType(pspSPREAD, &fParam);
 		}
 
-		return (1.0f);
+		return 1.0f;
 	}
 	else
 	{
 		if (!(m_nFlags & FLAG_SOUND_NO_SW_ATTENUATION))
 		{
-			float fSquaredDistance = fDistance * fDistance;
-			float fMinFactor =
-			    __min(fSquaredDistance, (m_RadiusSpecs.fMaxRadius2 - m_RadiusSpecs.fMinRadius2));
-			float fMaxFactor =
-			    __max(0.f, ((fMinFactor - m_RadiusSpecs.fMinRadius2) / m_RadiusSpecs.fMaxRadius2));
-			// fRatio = 1.0f - max(0,((fDist2-cs->GetSquardedMinRadius())/cs->GetSquardedMaxRadius()));
-			float fRatio = 1.0f - fMaxFactor;
-			return fRatio;
+			const float fSquaredDistance = fDistance * fDistance;
+			const float fMinFactor = __min(fSquaredDistance, (m_RadiusSpecs.fMaxRadius2 - m_RadiusSpecs.fMinRadius2));
+			const float fMaxFactor = __max(0.f, ((fMinFactor - m_RadiusSpecs.fMinRadius2) / m_RadiusSpecs.fMaxRadius2));
+
+			return 1.0f - fMaxFactor;
 		}
-		else
-			return (1.0f);
+
+		return 1.0f;
 	}
 }
 

--- a/Pak/Scripts/Entities/Items/XML/Ammo/A2AHomingMissile.xml
+++ b/Pak/Scripts/Entities/Items/XML/Ammo/A2AHomingMissile.xml
@@ -55,6 +55,13 @@
    	<!--<param name="effect" value="smoke_and_fire.weapon_stinger.missile" />-->    
 		<param name="scale" value="1" />
 		<param name="sound" value="sounds/physics:bullet_whiz:missile_whiz_loop" />
-	</trail>	
+	</trail>
+
+	<missile_approach>
+		<param name="sound" value="sounds/physics:bullet_whiz:missile_approach" />
+		<param name="prediction" value="2.0" />
+		<param name="pass_radius" value="150" />
+		<param name="distance_multiplier" value="2.5" />
+	</missile_approach>
 	
 </ammo>

--- a/Pak/Scripts/Entities/Items/XML/Ammo/Multiplayer/Rocket.xml
+++ b/Pak/Scripts/Entities/Items/XML/Ammo/Multiplayer/Rocket.xml
@@ -51,4 +51,10 @@
 		<param name="scale" value="0.45" />
 		<param name="sound" value="sounds/physics:bullet_whiz:missile_whiz_loop" />
 	</trail>
+	<missile_approach>
+		<param name="sound" value="sounds/physics:bullet_whiz:missile_approach" />
+		<param name="prediction" value="2.0" />
+		<param name="pass_radius" value="150" />
+		<param name="distance_multiplier" value="2.5" />
+	</missile_approach>
 </ammo>

--- a/Pak/Scripts/Entities/Items/XML/Ammo/Multiplayer/Turret_Rocket.xml
+++ b/Pak/Scripts/Entities/Items/XML/Ammo/Multiplayer/Turret_Rocket.xml
@@ -46,4 +46,10 @@
 		<param name="scale" value="0.45" />
 		<param name="sound" value="sounds/physics:bullet_whiz:missile_whiz_loop" />
 	</trail>
+	<missile_approach>
+		<param name="sound" value="sounds/physics:bullet_whiz:missile_approach" />
+		<param name="prediction" value="2.0" />
+		<param name="pass_radius" value="150" />
+		<param name="distance_multiplier" value="2.5" />
+	</missile_approach>
 </ammo>

--- a/Pak/Scripts/Entities/Items/XML/Ammo/Multiplayer/Vehicles/HelicopterMissile.xml
+++ b/Pak/Scripts/Entities/Items/XML/Ammo/Multiplayer/Vehicles/HelicopterMissile.xml
@@ -48,4 +48,11 @@
 		<param name="scale" value="1" />
 	</trail>	
 	
+	<missile_approach>
+		<param name="sound" value="sounds/physics:bullet_whiz:missile_approach" />
+		<param name="prediction" value="2.0" />
+		<param name="pass_radius" value="150" />
+		<param name="distance_multiplier" value="2.5" />
+	</missile_approach>
+	
 </ammo>

--- a/Pak/Scripts/Entities/Items/XML/Ammo/Rocket.xml
+++ b/Pak/Scripts/Entities/Items/XML/Ammo/Rocket.xml
@@ -49,4 +49,10 @@
 		<param name="scale" value="0.45" />
 		<param name="sound" value="sounds/physics:bullet_whiz:missile_whiz_loop" />
 	</trail>
+	<missile_approach>
+		<param name="sound" value="sounds/physics:bullet_whiz:missile_approach" />
+		<param name="prediction" value="2.0" />
+		<param name="pass_radius" value="150" />
+		<param name="distance_multiplier" value="2.5" />
+	</missile_approach>
 </ammo>

--- a/Pak/Scripts/Entities/Items/XML/Ammo/Turret_Rocket.xml
+++ b/Pak/Scripts/Entities/Items/XML/Ammo/Turret_Rocket.xml
@@ -45,4 +45,10 @@
 		<param name="scale" value="0.45" />
 		<param name="sound" value="sounds/physics:bullet_whiz:missile_whiz_loop" />
 	</trail>
+	<missile_approach>
+		<param name="sound" value="sounds/physics:bullet_whiz:missile_approach" />
+		<param name="prediction" value="2.0" />
+		<param name="pass_radius" value="150" />
+		<param name="distance_multiplier" value="2.5" />
+	</missile_approach>
 </ammo>

--- a/Pak/Scripts/Entities/Items/XML/Ammo/Vehicles/HelicopterMissile.xml
+++ b/Pak/Scripts/Entities/Items/XML/Ammo/Vehicles/HelicopterMissile.xml
@@ -46,6 +46,12 @@
 	<trail>
 		<param name="effect" value="smoke_and_fire.weapon_stinger.FFAR" />
 		<param name="scale" value="1" />
-	</trail>	
-	
+	</trail>
+
+	<missile_approach>
+		<param name="sound" value="sounds/physics:bullet_whiz:missile_approach" />
+		<param name="prediction" value="2.0" />
+		<param name="pass_radius" value="150" />
+		<param name="distance_multiplier" value="2.5" />
+	</missile_approach>
 </ammo>


### PR DESCRIPTION
## Add missile approach sound

Adds approach / fly-by sounds for missiles passing close to the player.

The missile trajectory is predicted from its current speed and direction, so faster missiles can trigger the sound earlier. Guided missiles can also trigger it again after a short cooldown if they make another pass.

Also includes a couple of SoundSystem fixes:
- Added `FLAG_SOUND_NO_3D_VELOCITY` for sounds where FMOD velocity/Doppler should not be applied.
- Fixed `Set3DPosition()` passing the velocity pointer based on `pvPosition` instead of `pvVelocity`.

The feature can be enabled/disabled with `mp_missileApproachSound`. It is enabled by default, but can be overwritten by the server.

Missile approach sounds are enabled per ammo type in XML:

```xml
<missile_approach>
	<param name="sound" value="sounds/physics:bullet_whiz:missile_approach" />
	<param name="prediction" value="2.0" />
	<param name="pass_radius" value="150" />
	<param name="distance_multiplier" value="2.5" />
</missile_approach>